### PR TITLE
arrow use largestring and date32/date64

### DIFF
--- a/connectorx/src/constants.rs
+++ b/connectorx/src/constants.rs
@@ -1,0 +1,1 @@
+pub(crate) const SECONDS_IN_DAY: i64 = 86_400;

--- a/connectorx/src/lib.rs
+++ b/connectorx/src/lib.rs
@@ -9,6 +9,7 @@ pub mod s3;
 pub mod typesystem;
 #[macro_use]
 pub mod macros;
+pub(crate) mod constants;
 pub mod data_order;
 pub mod destinations;
 pub mod dispatcher;

--- a/connectorx/tests/test_arrow.rs
+++ b/connectorx/tests/test_arrow.rs
@@ -1,4 +1,4 @@
-use arrow::array::{BooleanArray, Float64Array, Int64Array, StringArray};
+use arrow::array::{BooleanArray, Float64Array, Int64Array, LargeStringArray};
 use arrow::record_batch::RecordBatch;
 use connectorx::{
     destinations::arrow::ArrowDestination, sources::dummy::DummySource,
@@ -82,15 +82,17 @@ fn test_arrow() {
                 assert!(records[0]
                     .column(col)
                     .as_any()
-                    .downcast_ref::<StringArray>()
+                    .downcast_ref::<LargeStringArray>()
                     .unwrap()
-                    .eq(&StringArray::from(vec!["0", "1", "2", "3"])));
+                    .eq(&LargeStringArray::from(vec!["0", "1", "2", "3"])));
                 assert!(records[1]
                     .column(col)
                     .as_any()
-                    .downcast_ref::<StringArray>()
+                    .downcast_ref::<LargeStringArray>()
                     .unwrap()
-                    .eq(&StringArray::from(vec!["0", "1", "2", "3", "4", "5", "6"])));
+                    .eq(&LargeStringArray::from(vec![
+                        "0", "1", "2", "3", "4", "5", "6"
+                    ])));
             }
             4 => {
                 assert!(records[0]


### PR DESCRIPTION
This PR proposes using `LargeString` in favor of `String` type. The `String` datatype offsets the bytes in the `&str` buffer with an `i32` meaning that the columns can only hold 2^32 == ~2GB of string data. This limit is very easily met.

The `LargeString` uses an `i64` as offset type. A limit I don't see reached any time soon. :)

This also adds `Date32` and `Date64` for the naive dates/datetimes.


What would be needed next to make this work? I assume some python integration. And from the Rust side?