### PR TITLE
Init arrow type system and use that in postgres transport

### DIFF
--- a/connectorx/src/destinations/arrow/arrow_assoc.rs
+++ b/connectorx/src/destinations/arrow/arrow_assoc.rs
@@ -1,8 +1,8 @@
 use crate::constants::SECONDS_IN_DAY;
 use crate::errors::{ConnectorAgentError, Result};
 use arrow::array::{
-    ArrayBuilder, BooleanBuilder, Date32Builder, Date64Builder, Float64Builder, Int32Builder,
-    Int64Builder, LargeStringBuilder,
+    ArrayBuilder, BooleanBuilder, Date32Builder, Date64Builder, Float32Builder, Float64Builder,
+    Int32Builder, Int64Builder, LargeStringBuilder, UInt32Builder, UInt64Builder,
 };
 use arrow::datatypes::Field;
 use arrow::datatypes::{DataType as ArrowDataType, DateUnit};
@@ -18,6 +18,74 @@ pub trait ArrowAssoc {
     fn field(header: &str) -> Field;
 }
 
+impl ArrowAssoc for u32 {
+    type Builder = UInt32Builder;
+
+    fn builder(nrows: usize) -> UInt32Builder {
+        UInt32Builder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut UInt32Builder, value: u32) {
+        builder.append_value(value)?;
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::UInt64, false)
+    }
+}
+
+impl ArrowAssoc for Option<u32> {
+    type Builder = UInt32Builder;
+
+    fn builder(nrows: usize) -> UInt32Builder {
+        UInt32Builder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut UInt32Builder, value: Option<u32>) {
+        builder.append_option(value)?;
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::UInt32, true)
+    }
+}
+
+impl ArrowAssoc for u64 {
+    type Builder = UInt64Builder;
+
+    fn builder(nrows: usize) -> UInt64Builder {
+        UInt64Builder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut UInt64Builder, value: u64) {
+        builder.append_value(value)?;
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::UInt64, false)
+    }
+}
+
+impl ArrowAssoc for Option<u64> {
+    type Builder = UInt64Builder;
+
+    fn builder(nrows: usize) -> UInt64Builder {
+        UInt64Builder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut UInt64Builder, value: Option<u64>) {
+        builder.append_option(value)?;
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::UInt64, true)
+    }
+}
+
 impl ArrowAssoc for i32 {
     type Builder = Int32Builder;
 
@@ -31,7 +99,7 @@ impl ArrowAssoc for i32 {
     }
 
     fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::UInt64, false)
+        Field::new(header, ArrowDataType::Int32, false)
     }
 }
 
@@ -48,7 +116,7 @@ impl ArrowAssoc for Option<i32> {
     }
 
     fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::UInt64, true)
+        Field::new(header, ArrowDataType::Int32, true)
     }
 }
 
@@ -83,6 +151,40 @@ impl ArrowAssoc for Option<i64> {
 
     fn field(header: &str) -> Field {
         Field::new(header, ArrowDataType::Int64, false)
+    }
+}
+
+impl ArrowAssoc for f32 {
+    type Builder = Float32Builder;
+
+    fn builder(nrows: usize) -> Float32Builder {
+        Float32Builder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut Self::Builder, value: f32) {
+        builder.append_value(value)?;
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::Float64, false)
+    }
+}
+
+impl ArrowAssoc for Option<f32> {
+    type Builder = Float32Builder;
+
+    fn builder(nrows: usize) -> Float32Builder {
+        Float32Builder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut Self::Builder, value: Option<f32>) {
+        builder.append_option(value)?;
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::Float32, true)
     }
 }
 
@@ -182,6 +284,43 @@ impl ArrowAssoc for Option<String> {
     fn append(builder: &mut Self::Builder, value: Self) {
         match value {
             Some(s) => builder.append_value(s.as_str())?,
+            None => builder.append_null()?,
+        }
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::LargeUtf8, true)
+    }
+}
+
+impl ArrowAssoc for &str {
+    type Builder = LargeStringBuilder;
+
+    fn builder(nrows: usize) -> Self::Builder {
+        LargeStringBuilder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut Self::Builder, value: Self) {
+        builder.append_value(value)?;
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::LargeUtf8, false)
+    }
+}
+
+impl ArrowAssoc for Option<&str> {
+    type Builder = LargeStringBuilder;
+
+    fn builder(nrows: usize) -> Self::Builder {
+        LargeStringBuilder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut Self::Builder, value: Self) {
+        match value {
+            Some(s) => builder.append_value(s)?,
             None => builder.append_null()?,
         }
     }

--- a/connectorx/src/destinations/arrow/arrow_assoc.rs
+++ b/connectorx/src/destinations/arrow/arrow_assoc.rs
@@ -18,241 +18,86 @@ pub trait ArrowAssoc {
     fn field(header: &str) -> Field;
 }
 
-impl ArrowAssoc for u32 {
-    type Builder = UInt32Builder;
+macro_rules! impl_arrow_assoc {
+    ($T:ty, $AT:expr, $B:ty) => {
+        impl ArrowAssoc for $T {
+            type Builder = $B;
 
-    fn builder(nrows: usize) -> UInt32Builder {
-        UInt32Builder::new(nrows)
-    }
+            fn builder(nrows: usize) -> Self::Builder {
+                Self::Builder::new(nrows)
+            }
 
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut UInt32Builder, value: u32) {
-        builder.append_value(value)?;
-    }
+            #[throws(ConnectorAgentError)]
+            fn append(builder: &mut Self::Builder, value: Self) {
+                builder.append_value(value)?;
+            }
 
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::UInt64, false)
-    }
+            fn field(header: &str) -> Field {
+                Field::new(header, $AT, false)
+            }
+        }
+
+        impl ArrowAssoc for Option<$T> {
+            type Builder = $B;
+
+            fn builder(nrows: usize) -> Self::Builder {
+                Self::Builder::new(nrows)
+            }
+
+            #[throws(ConnectorAgentError)]
+            fn append(builder: &mut Self::Builder, value: Self) {
+                builder.append_option(value)?;
+            }
+
+            fn field(header: &str) -> Field {
+                Field::new(header, $AT, true)
+            }
+        }
+    };
 }
 
-impl ArrowAssoc for Option<u32> {
-    type Builder = UInt32Builder;
+impl_arrow_assoc!(u32, ArrowDataType::UInt32, UInt32Builder);
+impl_arrow_assoc!(u64, ArrowDataType::UInt64, UInt64Builder);
+impl_arrow_assoc!(i32, ArrowDataType::Int32, Int32Builder);
+impl_arrow_assoc!(i64, ArrowDataType::Int64, Int64Builder);
+impl_arrow_assoc!(f32, ArrowDataType::Float32, Float32Builder);
+impl_arrow_assoc!(f64, ArrowDataType::Float64, Float64Builder);
+impl_arrow_assoc!(bool, ArrowDataType::Boolean, BooleanBuilder);
 
-    fn builder(nrows: usize) -> UInt32Builder {
-        UInt32Builder::new(nrows)
-    }
+impl ArrowAssoc for &str {
+    type Builder = LargeStringBuilder;
 
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut UInt32Builder, value: Option<u32>) {
-        builder.append_option(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::UInt32, true)
-    }
-}
-
-impl ArrowAssoc for u64 {
-    type Builder = UInt64Builder;
-
-    fn builder(nrows: usize) -> UInt64Builder {
-        UInt64Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut UInt64Builder, value: u64) {
-        builder.append_value(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::UInt64, false)
-    }
-}
-
-impl ArrowAssoc for Option<u64> {
-    type Builder = UInt64Builder;
-
-    fn builder(nrows: usize) -> UInt64Builder {
-        UInt64Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut UInt64Builder, value: Option<u64>) {
-        builder.append_option(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::UInt64, true)
-    }
-}
-
-impl ArrowAssoc for i32 {
-    type Builder = Int32Builder;
-
-    fn builder(nrows: usize) -> Int32Builder {
-        Int32Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Int32Builder, value: i32) {
-        builder.append_value(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Int32, false)
-    }
-}
-
-impl ArrowAssoc for Option<i32> {
-    type Builder = Int32Builder;
-
-    fn builder(nrows: usize) -> Int32Builder {
-        Int32Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Int32Builder, value: Option<i32>) {
-        builder.append_option(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Int32, true)
-    }
-}
-
-impl ArrowAssoc for i64 {
-    type Builder = Int64Builder;
-
-    fn builder(nrows: usize) -> Int64Builder {
-        Int64Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Int64Builder, value: i64) {
-        builder.append_value(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Int64, false)
-    }
-}
-
-impl ArrowAssoc for Option<i64> {
-    type Builder = Int64Builder;
-
-    fn builder(nrows: usize) -> Int64Builder {
-        Int64Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Int64Builder, value: Option<i64>) {
-        builder.append_option(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Int64, false)
-    }
-}
-
-impl ArrowAssoc for f32 {
-    type Builder = Float32Builder;
-
-    fn builder(nrows: usize) -> Float32Builder {
-        Float32Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Self::Builder, value: f32) {
-        builder.append_value(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Float64, false)
-    }
-}
-
-impl ArrowAssoc for Option<f32> {
-    type Builder = Float32Builder;
-
-    fn builder(nrows: usize) -> Float32Builder {
-        Float32Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Self::Builder, value: Option<f32>) {
-        builder.append_option(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Float32, true)
-    }
-}
-
-impl ArrowAssoc for f64 {
-    type Builder = Float64Builder;
-
-    fn builder(nrows: usize) -> Float64Builder {
-        Float64Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Self::Builder, value: f64) {
-        builder.append_value(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Float64, false)
-    }
-}
-
-impl ArrowAssoc for Option<f64> {
-    type Builder = Float64Builder;
-
-    fn builder(nrows: usize) -> Float64Builder {
-        Float64Builder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Self::Builder, value: Option<f64>) {
-        builder.append_option(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Float64, true)
-    }
-}
-
-impl ArrowAssoc for bool {
-    type Builder = BooleanBuilder;
-
-    fn builder(nrows: usize) -> BooleanBuilder {
-        BooleanBuilder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Self::Builder, value: bool) {
-        builder.append_value(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Boolean, false)
-    }
-}
-
-impl ArrowAssoc for Option<bool> {
-    type Builder = BooleanBuilder;
-
-    fn builder(nrows: usize) -> BooleanBuilder {
-        BooleanBuilder::new(nrows)
+    fn builder(nrows: usize) -> Self::Builder {
+        LargeStringBuilder::new(nrows)
     }
 
     #[throws(ConnectorAgentError)]
     fn append(builder: &mut Self::Builder, value: Self) {
-        builder.append_option(value)?;
+        builder.append_value(value)?;
     }
 
     fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::Boolean, true)
+        Field::new(header, ArrowDataType::LargeUtf8, false)
+    }
+}
+
+impl ArrowAssoc for Option<&str> {
+    type Builder = LargeStringBuilder;
+
+    fn builder(nrows: usize) -> Self::Builder {
+        LargeStringBuilder::new(nrows)
+    }
+
+    #[throws(ConnectorAgentError)]
+    fn append(builder: &mut Self::Builder, value: Self) {
+        match value {
+            Some(s) => builder.append_value(s)?,
+            None => builder.append_null()?,
+        }
+    }
+
+    fn field(header: &str) -> Field {
+        Field::new(header, ArrowDataType::LargeUtf8, true)
     }
 }
 
@@ -284,43 +129,6 @@ impl ArrowAssoc for Option<String> {
     fn append(builder: &mut Self::Builder, value: Self) {
         match value {
             Some(s) => builder.append_value(s.as_str())?,
-            None => builder.append_null()?,
-        }
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::LargeUtf8, true)
-    }
-}
-
-impl ArrowAssoc for &str {
-    type Builder = LargeStringBuilder;
-
-    fn builder(nrows: usize) -> Self::Builder {
-        LargeStringBuilder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Self::Builder, value: Self) {
-        builder.append_value(value)?;
-    }
-
-    fn field(header: &str) -> Field {
-        Field::new(header, ArrowDataType::LargeUtf8, false)
-    }
-}
-
-impl ArrowAssoc for Option<&str> {
-    type Builder = LargeStringBuilder;
-
-    fn builder(nrows: usize) -> Self::Builder {
-        LargeStringBuilder::new(nrows)
-    }
-
-    #[throws(ConnectorAgentError)]
-    fn append(builder: &mut Self::Builder, value: Self) {
-        match value {
-            Some(s) => builder.append_value(s)?,
             None => builder.append_null()?,
         }
     }

--- a/connectorx/src/destinations/arrow/mod.rs
+++ b/connectorx/src/destinations/arrow/mod.rs
@@ -1,3 +1,7 @@
+mod arrow_assoc;
+mod funcs;
+pub mod types;
+
 use super::{Consume, Destination, DestinationPartition};
 use crate::data_order::DataOrder;
 use crate::destinations::arrow::types::ArrowTypeSystem;
@@ -12,10 +16,6 @@ use funcs::{FFinishBuilder, FNewBuilder, FNewField};
 use itertools::Itertools;
 use std::any::Any;
 use std::sync::Arc;
-
-mod arrow_assoc;
-mod funcs;
-pub mod types;
 
 type Builder = Box<dyn Any + Send>;
 type Builders = Vec<Builder>;

--- a/connectorx/src/destinations/arrow/mod.rs
+++ b/connectorx/src/destinations/arrow/mod.rs
@@ -1,6 +1,6 @@
 use super::{Consume, Destination, DestinationPartition};
 use crate::data_order::DataOrder;
-use crate::dummy_typesystem::DummyTypeSystem;
+use crate::destinations::arrow::types::ArrowTypeSystem;
 use crate::errors::{ConnectorAgentError, Result};
 use crate::typesystem::{Realize, TypeAssoc, TypeSystem};
 use anyhow::anyhow;
@@ -15,13 +15,14 @@ use std::sync::Arc;
 
 mod arrow_assoc;
 mod funcs;
+pub mod types;
 
 type Builder = Box<dyn Any + Send>;
 type Builders = Vec<Builder>;
 
 pub struct ArrowDestination {
     nrows: usize,
-    schema: Vec<DummyTypeSystem>,
+    schema: Vec<ArrowTypeSystem>,
     builders: Vec<Builders>,
 }
 
@@ -43,7 +44,7 @@ impl ArrowDestination {
 
 impl Destination for ArrowDestination {
     const DATA_ORDERS: &'static [DataOrder] = &[DataOrder::ColumnMajor, DataOrder::RowMajor];
-    type TypeSystem = DummyTypeSystem;
+    type TypeSystem = ArrowTypeSystem;
     type Partition<'a> = ArrowPartitionWriter<'a>;
 
     #[throws(ConnectorAgentError)]
@@ -51,7 +52,7 @@ impl Destination for ArrowDestination {
         &mut self,
         nrows: usize,
         _names: &[S],
-        schema: &[DummyTypeSystem],
+        schema: &[ArrowTypeSystem],
         _data_order: DataOrder,
     ) {
         // cannot really create builders since do not know each partition size here
@@ -82,7 +83,7 @@ impl Destination for ArrowDestination {
             .collect()
     }
 
-    fn schema(&self) -> &[DummyTypeSystem] {
+    fn schema(&self) -> &[ArrowTypeSystem] {
         self.schema.as_slice()
     }
 }
@@ -115,13 +116,13 @@ impl ArrowDestination {
 
 pub struct ArrowPartitionWriter<'a> {
     nrows: usize,
-    schema: Vec<DummyTypeSystem>,
+    schema: Vec<ArrowTypeSystem>,
     builders: &'a mut Builders,
     current_col: usize,
 }
 
 impl<'a> ArrowPartitionWriter<'a> {
-    fn new(schema: Vec<DummyTypeSystem>, builders: &'a mut Builders, nrows: usize) -> Self {
+    fn new(schema: Vec<ArrowTypeSystem>, builders: &'a mut Builders, nrows: usize) -> Self {
         ArrowPartitionWriter {
             nrows,
             schema,
@@ -132,7 +133,7 @@ impl<'a> ArrowPartitionWriter<'a> {
 }
 
 impl<'a> DestinationPartition<'a> for ArrowPartitionWriter<'a> {
-    type TypeSystem = DummyTypeSystem;
+    type TypeSystem = ArrowTypeSystem;
 
     fn nrows(&self) -> usize {
         self.nrows

--- a/connectorx/src/destinations/arrow/types.rs
+++ b/connectorx/src/destinations/arrow/types.rs
@@ -19,16 +19,16 @@ pub enum ArrowTypeSystem {
 impl_typesystem! {
     system= ArrowTypeSystem,
     mappings = {
-        { Float64 => f64               }
-        { Float32 => f32               }
-        { Int32 => i32                 }
-        { Int64 => i64                 }
-        { UInt32 => u32                }
-        { UInt64 => u64                }
-        { LargeUtf8 => String          }
-        { Date32 => NaiveDate          }
-        { Date64 => NaiveDateTime      }
-        { Boolean => bool              }
-        { DateTimeTz => DateTime<Utc>  }
+        { Float64    => f64           }
+        { Float32    => f32           }
+        { Int32      => i32           }
+        { Int64      => i64           }
+        { UInt32     => u32           }
+        { UInt64     => u64           }
+        { LargeUtf8  => String        }
+        { Date32     => NaiveDate     }
+        { Date64     => NaiveDateTime }
+        { Boolean    => bool          }
+        { DateTimeTz => DateTime<Utc> }
     }
 }

--- a/connectorx/src/destinations/arrow/types.rs
+++ b/connectorx/src/destinations/arrow/types.rs
@@ -1,0 +1,34 @@
+use crate::impl_typesystem;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ArrowTypeSystem {
+    Float32(bool),
+    Float64(bool),
+    Int32(bool),
+    Int64(bool),
+    UInt32(bool),
+    UInt64(bool),
+    LargeUtf8(bool),
+    Date32(bool),
+    Date64(bool),
+    Boolean(bool),
+    DateTimeTz(bool),
+}
+
+impl_typesystem! {
+    system= ArrowTypeSystem,
+    mappings = {
+        { Float64 => f64               }
+        { Float32 => f32               }
+        { Int32 => i32                 }
+        { Int64 => i64                 }
+        { UInt32 => u32                }
+        { UInt64 => u64                }
+        { LargeUtf8 => String          }
+        { Date32 => NaiveDate          }
+        { Date64 => NaiveDateTime      }
+        { Boolean => bool              }
+        { DateTimeTz => DateTime<Utc>  }
+    }
+}

--- a/connectorx/src/transports/dummy_arrow.rs
+++ b/connectorx/src/transports/dummy_arrow.rs
@@ -15,7 +15,7 @@ impl_transport!(
         { F64[f64]                => Float64[f64]               | conversion all}
         { I64[i64]                => Int64[i64]                 | conversion all}
         { Bool[bool]              => Boolean[bool]              | conversion all}
-        { String[String]          => LargeUtf8[String]          | conversion half}
+        { String[String]          => LargeUtf8[String]          | conversion all}
         { DateTime[DateTime<Utc>] => Date64[NaiveDateTime]      | conversion half}
     }
 );
@@ -35,11 +35,5 @@ impl TypeConversion<NaiveDateTime, DateTime<Utc>> for DummyArrowTransport {
 impl TypeConversion<NaiveDate, DateTime<Utc>> for DummyArrowTransport {
     fn convert(val: NaiveDate) -> DateTime<Utc> {
         DateTime::from_utc(val.and_hms(0, 0, 0), Utc)
-    }
-}
-
-impl TypeConversion<String, String> for DummyArrowTransport {
-    fn convert(val: String) -> String {
-        val
     }
 }

--- a/connectorx/src/transports/postgres_arrow.rs
+++ b/connectorx/src/transports/postgres_arrow.rs
@@ -23,7 +23,7 @@ impl_transport!(
         { Timestamp[NaiveDateTime]   => Date64[NaiveDateTime]   | conversion half }
         { Date[NaiveDate]            => Date32[NaiveDate]       | conversion half }
         { UUID[Uuid]                 => LargeUtf8[String]       | conversion half }
-        { Char[&'r str]              => LargeUtf8[String]       | conversion none}
+        { Char[&'r str]              => LargeUtf8[String]       | conversion none }
         // { Time[NaiveTime]            => String[String]       | conversion half }
     }
 );
@@ -43,12 +43,6 @@ impl TypeConversion<NaiveTime, String> for PostgresArrowTransport {
 impl<'r> TypeConversion<&'r str, String> for PostgresArrowTransport {
     fn convert(val: &'r str) -> String {
         val.to_string()
-    }
-}
-
-impl<'r> TypeConversion<&'r str, &'r str> for PostgresArrowTransport {
-    fn convert(val: &'r str) -> &'r str {
-        val
     }
 }
 

--- a/connectorx/src/transports/postgres_arrow.rs
+++ b/connectorx/src/transports/postgres_arrow.rs
@@ -1,5 +1,4 @@
-use crate::destinations::arrow::ArrowDestination;
-use crate::dummy_typesystem::DummyTypeSystem;
+use crate::destinations::arrow::{types::ArrowTypeSystem, ArrowDestination};
 use crate::sources::postgres::{Binary, PostgresSource, PostgresTypeSystem};
 use crate::typesystem::TypeConversion;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
@@ -9,24 +8,23 @@ pub struct PostgresArrowTransport;
 
 impl_transport!(
     name = PostgresArrowTransport,
-    systems = PostgresTypeSystem => DummyTypeSystem,
+    systems = PostgresTypeSystem => ArrowTypeSystem,
     route = PostgresSource<Binary> => ArrowDestination,
     mappings = {
-        { Float4[f32]                => F64[f64]                | conversion all }
-        { Float8[f64]                => F64[f64]                | conversion all }
-        { Int2[i16]                  => I64[i64]                | conversion all }
-        { Int4[i32]                  => I64[i64]                | conversion all }
-        { Int8[i64]                  => I64[i64]                | conversion all }
-        { Bool[bool]                 => Bool[bool]              | conversion all  }
-        { Text[&'r str]              => String[String]          | conversion half }
-        { BpChar[&'r str]            => String[String]          | conversion none }
-        { VarChar[&'r str]           => String[String]          | conversion none }
-        { Timestamp[NaiveDateTime]   => DateTime[DateTime<Utc>] | conversion half }
-        { TimestampTz[DateTime<Utc>] => DateTime[DateTime<Utc>] | conversion all }
-        { Date[NaiveDate]            => DateTime[DateTime<Utc>] | conversion half }
-        { UUID[Uuid]                 => String[String]          | conversion half }
-        { Char[&'r str]              => String[String]          | conversion none}
-        // { Time[NaiveTime]            => String[String]          | conversion half }
+        { Float4[f32]                => Float32[f32]            | conversion all }
+        { Float8[f64]                => Float64[f64]            | conversion all }
+        { Int2[i16]                  => Int32[i32]              | conversion all }
+        { Int4[i32]                  => Int32[i32]              | conversion all }
+        { Int8[i64]                  => Int64[i64]              | conversion all }
+        { Bool[bool]                 => Boolean[bool]           | conversion all  }
+        { Text[&'r str]              => LargeUtf8[String]       | conversion half }
+        { BpChar[&'r str]            => LargeUtf8[String]       | conversion none }
+        { VarChar[&'r str]           => LargeUtf8[String]       | conversion none }
+        { Timestamp[NaiveDateTime]   => Date64[NaiveDateTime]   | conversion half }
+        { Date[NaiveDate]            => Date32[NaiveDate]       | conversion half }
+        { UUID[Uuid]                 => LargeUtf8[String]       | conversion half }
+        { Char[&'r str]              => LargeUtf8[String]       | conversion none}
+        // { Time[NaiveTime]            => String[String]       | conversion half }
     }
 );
 
@@ -45,6 +43,24 @@ impl TypeConversion<NaiveTime, String> for PostgresArrowTransport {
 impl<'r> TypeConversion<&'r str, String> for PostgresArrowTransport {
     fn convert(val: &'r str) -> String {
         val.to_string()
+    }
+}
+
+impl<'r> TypeConversion<&'r str, &'r str> for PostgresArrowTransport {
+    fn convert(val: &'r str) -> &'r str {
+        val
+    }
+}
+
+impl TypeConversion<NaiveDate, NaiveDate> for PostgresArrowTransport {
+    fn convert(val: NaiveDate) -> NaiveDate {
+        val
+    }
+}
+
+impl TypeConversion<NaiveDateTime, NaiveDateTime> for PostgresArrowTransport {
+    fn convert(val: NaiveDateTime) -> NaiveDateTime {
+        val
     }
 }
 


### PR DESCRIPTION
This PR adds an arrow types system and uses that type system in `PostgresArrowTransport`.

I just pleased the type system here, so please take a good look. :)

Some questions:

* what does the this [bool]( https://github.com/sfu-db/connector-x/blob/3c56c539d29bc252d205a20700edd63efec301ab/connectorx-python/src/pandas/types.rs#L8) do?

A premature optimization, but if I understand correctly we can also implement `ArrowAssoc` for `&str` and `Option<&str>`, add that to the type system and thereby reduce an allocation of `String`?