### PR TITLE
Automatically select 'text' protocol for clickhouse-prefixed connection strings

### DIFF
--- a/connectorx-python/connectorx/__init__.py
+++ b/connectorx-python/connectorx/__init__.py
@@ -99,7 +99,7 @@ def read_sql(
     if not protocol:
         # note: redshift/clickhouse are not compatible with the 'binary' protocol, and use other database
         # drivers to connect. set a compatible protocol and masquerade as the appropriate backend.
-        backend, connection_details = conn.split(":",1)
+        backend, connection_details = conn.split(":",1) if conn else ("","")
         if "redshift" in backend:
             conn = f"postgresql:{connection_details}"
             protocol = "cursor"

--- a/connectorx-python/connectorx/__init__.py
+++ b/connectorx-python/connectorx/__init__.py
@@ -97,12 +97,15 @@ def read_sql(
         raise ValueError("query must be either str or a list of str")
 
     if not protocol:
-        # note: redshift cannot currently use the faster binary/csv protocols.
-        # set compatible protocol ('cursor') and masquerade as postgres.
+        # note: redshift/clickhouse are not compatible with the 'binary' protocol, and use other database
+        # drivers to connect. set a compatible protocol and masquerade as the appropriate backend.
         backend, connection_details = conn.split(":",1)
         if "redshift" in backend:
             conn = f"postgresql:{connection_details}"
             protocol = "cursor"
+        elif "clickhouse" in backend:
+            conn = f"mysql:{connection_details}"
+            protocol = "text"
         else:
             protocol = "binary"
 


### PR DESCRIPTION
much the same as the previous redshift patch, but this one is for ease of use with clickhouse. sits in the same block of code quite neatly, and doesn't disturb any other defaults. hopefully of similar utility ;)

`read_sql("clickhouse://...details...", query=...)` => `read_sql("mysql://...details...", query=..., protocol='text')`