### PR TITLE
Oracle stmt array size 1k

### DIFF
--- a/connectorx/src/constants.rs
+++ b/connectorx/src/constants.rs
@@ -1,6 +1,7 @@
 #[cfg(any(feature = "dst_arrow", feature = "dst_arrow2"))]
 pub(crate) const SECONDS_IN_DAY: i64 = 86_400;
 
+#[allow(dead_code)]
 const KILO: usize = 1 << 10;
 
 #[cfg(any(feature = "dst_arrow", feature = "dst_arrow2"))]
@@ -15,4 +16,4 @@ pub const RECORD_BATCH_SIZE: usize = 64 * KILO;
 pub const DB_BUFFER_SIZE: usize = 32;
 
 #[cfg(any(feature = "src_oracle"))]
-pub const ORACLE_ARRAY_SIZE: u32 = 1024;
+pub const ORACLE_ARRAY_SIZE: u32 = (1 * KILO) as u32;

--- a/connectorx/src/constants.rs
+++ b/connectorx/src/constants.rs
@@ -13,3 +13,6 @@ pub const RECORD_BATCH_SIZE: usize = 64 * KILO;
     feature = "src_mssql"
 ))]
 pub const DB_BUFFER_SIZE: usize = 32;
+
+#[cfg(any(feature = "src_oracle"))]
+pub const ORACLE_ARRAY_SIZE: u32 = 1024;


### PR DESCRIPTION
https://github.com/sfu-db/connector-x/issues/127

Varying the array size could affect the performance when no partition is applied , switch to using stmt from 100 (default) to 1K(905s -> 834s)

![Oracle vary FetchArraySize](https://user-images.githubusercontent.com/5569610/153070297-ccb78469-5e99-4738-9846-a0d470735997.png)

