### PR TITLE
pin git submodule using https protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "federated-query"]
 	path = federated-query
-	url = git@github.com:sfu-db/federated-query.git
+	url = https://github.com/sfu-db/federated-query.git
+	branch = main


### PR DESCRIPTION
Using git/ssh protocl for submodule repo prevents us from pulling
connectorx as a cargo dependency by a specific git commit.