### PR TITLE
[WIP] Adds ltree string type

### DIFF
--- a/connectorx-python/connectorx/tests/test_postgres.py
+++ b/connectorx-python/connectorx/tests/test_postgres.py
@@ -450,7 +450,7 @@ def test_postgres_with_index_col(postgres_url: str) -> None:
 
 
 def test_postgres_types_binary(postgres_url: str) -> None:
-    query = "SELECT test_date, test_timestamp, test_timestamptz, test_int16, test_int64, test_float32, test_numeric, test_bpchar, test_char, test_varchar, test_uuid, test_time, test_json, test_jsonb, test_bytea, test_enum, test_f4array, test_f8array, test_narray, test_i2array, test_i4array, test_i8array, test_citext FROM test_types"
+    query = "SELECT test_date, test_timestamp, test_timestamptz, test_int16, test_int64, test_float32, test_numeric, test_bpchar, test_char, test_varchar, test_uuid, test_time, test_json, test_jsonb, test_bytea, test_enum, test_f4array, test_f8array, test_narray, test_i2array, test_i4array, test_i8array, test_citext, test_ltree FROM test_types"
     df = read_sql(postgres_url, query)
     expected = pd.DataFrame(
         index=range(4),
@@ -549,13 +549,14 @@ def test_postgres_types_binary(postgres_url: str) -> None:
                 dtype="object",
             ),
             "test_citext": pd.Series(["str_citext", "", "s", None], dtype="object"),
+            "test_ltree": pd.Series(["A.B.C.D", "A.B.E", "A", None], dtype="object"),
         },
     )
     assert_frame_equal(df, expected, check_names=True)
 
 
 def test_postgres_types_csv(postgres_url: str) -> None:
-    query = "SELECT test_date, test_timestamp, test_timestamptz, test_int16, test_int64, test_float32, test_numeric, test_bpchar, test_char, test_varchar, test_uuid, test_time, test_json, test_jsonb, test_bytea, test_enum::text, test_f4array, test_f8array, test_narray, test_i2array, test_i4array, test_i8array, test_citext FROM test_types"
+    query = "SELECT test_date, test_timestamp, test_timestamptz, test_int16, test_int64, test_float32, test_numeric, test_bpchar, test_char, test_varchar, test_uuid, test_time, test_json, test_jsonb, test_bytea, test_enum::text, test_f4array, test_f8array, test_narray, test_i2array, test_i4array, test_i8array, test_citext, test_ltree FROM test_types"
     df = read_sql(postgres_url, query, protocol="csv")
     expected = pd.DataFrame(
         index=range(4),
@@ -654,13 +655,14 @@ def test_postgres_types_csv(postgres_url: str) -> None:
                 dtype="object",
             ),
             "test_citext": pd.Series(["str_citext", None, "s", None], dtype="object"),
+            "test_ltree": pd.Series(["A.B.C.D", "A.B.E", "A", None], dtype="object"),
         },
     )
     assert_frame_equal(df, expected, check_names=True)
 
 
 def test_postgres_types_cursor(postgres_url: str) -> None:
-    query = "SELECT test_date, test_timestamp, test_timestamptz, test_int16, test_int64, test_float32, test_numeric, test_bpchar, test_char, test_varchar, test_uuid, test_time, test_json, test_jsonb, test_bytea, test_enum::text, test_f4array, test_f8array, test_narray, test_i2array, test_i4array, test_i8array, test_citext FROM test_types"
+    query = "SELECT test_date, test_timestamp, test_timestamptz, test_int16, test_int64, test_float32, test_numeric, test_bpchar, test_char, test_varchar, test_uuid, test_time, test_json, test_jsonb, test_bytea, test_enum::text, test_f4array, test_f8array, test_narray, test_i2array, test_i4array, test_i8array, test_citext, test_ltree FROM test_types"
     df = read_sql(postgres_url, query, protocol="cursor")
     expected = pd.DataFrame(
         index=range(4),
@@ -759,6 +761,7 @@ def test_postgres_types_cursor(postgres_url: str) -> None:
                 dtype="object",
             ),
             "test_citext": pd.Series(["str_citext", "", "s", None], dtype="object"),
+            "test_ltree": pd.Series(["A.B.C.D", "A.B.E", "A", None], dtype="object"),
         },
     )
     assert_frame_equal(df, expected, check_names=True)

--- a/connectorx-python/connectorx/tests/test_postgres.py
+++ b/connectorx-python/connectorx/tests/test_postgres.py
@@ -450,7 +450,7 @@ def test_postgres_with_index_col(postgres_url: str) -> None:
 
 
 def test_postgres_types_binary(postgres_url: str) -> None:
-    query = "SELECT test_date, test_timestamp, test_timestamptz, test_int16, test_int64, test_float32, test_numeric, test_bpchar, test_char, test_varchar, test_uuid, test_time, test_json, test_jsonb, test_bytea, test_enum, test_f4array, test_f8array, test_narray, test_i2array, test_i4array, test_i8array, test_citext, test_ltree FROM test_types"
+    query = "SELECT test_date, test_timestamp, test_timestamptz, test_int16, test_int64, test_float32, test_numeric, test_bpchar, test_char, test_varchar, test_uuid, test_time, test_json, test_jsonb, test_bytea, test_enum, test_f4array, test_f8array, test_narray, test_i2array, test_i4array, test_i8array, test_citext FROM test_types"
     df = read_sql(postgres_url, query)
     expected = pd.DataFrame(
         index=range(4),
@@ -549,7 +549,7 @@ def test_postgres_types_binary(postgres_url: str) -> None:
                 dtype="object",
             ),
             "test_citext": pd.Series(["str_citext", "", "s", None], dtype="object"),
-            "test_ltree": pd.Series(["A.B.C.D", "A.B.E", "A", None], dtype="object"),
+            # "test_ltree": pd.Series(["A.B.C.D", "A.B.E", "A", None], dtype="object"), # waiting for https://github.com/sfackler/rust-postgres/issues/960
         },
     )
     assert_frame_equal(df, expected, check_names=True)

--- a/connectorx/src/sources/postgres/typesystem.rs
+++ b/connectorx/src/sources/postgres/typesystem.rs
@@ -83,7 +83,7 @@ impl<'a> From<&'a Type> for PostgresTypeSystem {
             "_numeric" => NumericArray(true),
             "bool" => Bool(true),
             "char" => Char(true),
-            "text" | "citext" => Text(true),
+            "text" | "citext" | "ltree" => Text(true),
             "bpchar" => BpChar(true),
             "varchar" => VarChar(true),
             "bytea" => ByteA(true),

--- a/docs/databases/postgres.md
+++ b/docs/databases/postgres.md
@@ -41,6 +41,7 @@ cx.read_sql(conn, query)                                        # read data from
 | JSON            | object                    |                                    |
 | JSONB           | object                    |                                    |
 | ENUM            | object                    | need to convert enum column to text manually (`::text`) when using `csv` and `cursor` protocol |
+| ltree           | object                    | binary protocol returns with a hex char prefix. Check https://github.com/sfu-db/connector-x/pull/382 and https://github.com/sfackler/rust-postgres/issues/960 for status |
 | INT2[]          | object                    | list of i64                        |
 | INT4[]          | object                    | list of i64                        |
 | INT8[]          | object                    | list of i64                        |

--- a/scripts/postgres.sql
+++ b/scripts/postgres.sql
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS test_str;
 DROP TABLE IF EXISTS test_types;
 DROP TYPE IF EXISTS happiness;
 DROP EXTENSION IF EXISTS citext;
+DROP EXTENSION IF EXISTS ltree;
 
 CREATE TABLE IF NOT EXISTS test_table(
     test_int INTEGER NOT NULL,
@@ -37,6 +38,7 @@ INSERT INTO test_str VALUES (8, '', NULL);
 
 CREATE TYPE happiness AS ENUM ('happy', 'very happy', 'ecstatic');
 CREATE EXTENSION citext;
+CREATE EXTENSION ltree;
 CREATE TABLE IF NOT EXISTS test_types(
     test_date DATE,
     test_timestamp TIMESTAMP,
@@ -61,13 +63,14 @@ CREATE TABLE IF NOT EXISTS test_types(
     test_i2array SMALLINT[],
     test_i4array Integer[],
     test_i8array BIGINT[],
-    test_citext CITEXT
+    test_citext CITEXT,
+    test_ltree ltree
 );
 
-INSERT INTO test_types VALUES ('1970-01-01', '1970-01-01 00:00:01', '1970-01-01 00:00:01-00', 0, -9223372036854775808, NULL, NULL, 'a', 'a', NULL, '86b494cc-96b2-11eb-9298-3e22fbb9fe9d', '08:12:40', '1 year 2 months 3 days', '{"customer": "John Doe", "items": {"product": "Beer","qty": 6}}', '{"product": "Beer","qty": 6}', NULL, 'happy','{}', '{}', '{}', '{-1, 0, 1}', '{-1, 0, 1123}', '{-9223372036854775808, 9223372036854775807}', 'str_citext');
-INSERT INTO test_types VALUES ('2000-02-28', '2000-02-28 12:00:10', '2000-02-28 12:00:10-04', 1, 0, 3.1415926535, 521.34, 'bb', 'b', 'bb', '86b49b84-96b2-11eb-9298-3e22fbb9fe9d', NULL, '2 weeks ago', '{"customer": "Lily Bush", "items": {"product": "Diaper","qty": 24}}', '{"product": "Diaper","qty": 24}', 'Здра́вствуйте', 'very happy', NULL, NULL, NULL, '{}', '{}', '{}', '');
-INSERT INTO test_types VALUES ('2038-01-18', '2038-01-18 23:59:59', '2038-01-18 23:59:59+08', 2, 9223372036854775807, 2.71, 999.99, 'ccc', NULL, 'c', '86b49c42-96b2-11eb-9298-3e22fbb9fe9d', '23:00:10', '3 months 2 days ago', '{"customer": "Josh William", "items": {"product": "Toy Car","qty": 1}}', '{"product": "Toy Car","qty": 1}', '', 'ecstatic', '{123.123}', '{-1e-307, 1e308}', '{521.34}', '{-32768, 32767}', '{-2147483648, 2147483647}', '{0}', 's');
-INSERT INTO test_types VALUES (NULL, NULL, NULL, 3, NULL, 0.00, -1e-37, NULL, 'd', 'defghijklm', NULL, '18:30:00', '3 year', NULL, NULL, '😜', NULL, '{-1e-37, 1e37}', '{0.000234, -12.987654321}', '{0.12, 333.33, 22.22}', NULL, NULL, NULL, NULL);
+INSERT INTO test_types VALUES ('1970-01-01', '1970-01-01 00:00:01', '1970-01-01 00:00:01-00', 0, -9223372036854775808, NULL, NULL, 'a', 'a', NULL, '86b494cc-96b2-11eb-9298-3e22fbb9fe9d', '08:12:40', '1 year 2 months 3 days', '{"customer": "John Doe", "items": {"product": "Beer","qty": 6}}', '{"product": "Beer","qty": 6}', NULL, 'happy','{}', '{}', '{}', '{-1, 0, 1}', '{-1, 0, 1123}', '{-9223372036854775808, 9223372036854775807}', 'str_citext', 'A.B.C.D');
+INSERT INTO test_types VALUES ('2000-02-28', '2000-02-28 12:00:10', '2000-02-28 12:00:10-04', 1, 0, 3.1415926535, 521.34, 'bb', 'b', 'bb', '86b49b84-96b2-11eb-9298-3e22fbb9fe9d', NULL, '2 weeks ago', '{"customer": "Lily Bush", "items": {"product": "Diaper","qty": 24}}', '{"product": "Diaper","qty": 24}', 'Здра́вствуйте', 'very happy', NULL, NULL, NULL, '{}', '{}', '{}', '', 'A.B.E');
+INSERT INTO test_types VALUES ('2038-01-18', '2038-01-18 23:59:59', '2038-01-18 23:59:59+08', 2, 9223372036854775807, 2.71, 999.99, 'ccc', NULL, 'c', '86b49c42-96b2-11eb-9298-3e22fbb9fe9d', '23:00:10', '3 months 2 days ago', '{"customer": "Josh William", "items": {"product": "Toy Car","qty": 1}}', '{"product": "Toy Car","qty": 1}', '', 'ecstatic', '{123.123}', '{-1e-307, 1e308}', '{521.34}', '{-32768, 32767}', '{-2147483648, 2147483647}', '{0}', 's', 'A');
+INSERT INTO test_types VALUES (NULL, NULL, NULL, 3, NULL, 0.00, -1e-37, NULL, 'd', 'defghijklm', NULL, '18:30:00', '3 year', NULL, NULL, '😜', NULL, '{-1e-37, 1e37}', '{0.000234, -12.987654321}', '{0.12, 333.33, 22.22}', NULL, NULL, NULL, NULL, NULL);
 
 CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
     BEGIN


### PR DESCRIPTION
This adds ltree type as a string, using commit as guide 9ae1ecb644742c6aaa29c2f0a0f1e3bd1219bae5. 
ltree is available in the driver since https://github.com/sfackler/rust-postgres/issues/389
Works with all protocols, but has an issue with Binary:

![image](https://user-images.githubusercontent.com/12375421/197640119-0008fbdc-b56f-4779-b015-2de08b5be69f.png)

When I inspect the data in the shell, the dataframe that came from Postgres shows this hex prefix.
![image](https://user-images.githubusercontent.com/12375421/197639031-a3823937-33ca-4131-af1d-a14211094448.png)

I'm looking for help delivering this, and other Postgres Types. Thanks!
Fixes: #381