### PR TITLE
Polars uses Arrow2 in their code. So should this lib

### DIFF
--- a/connectorx-python/connectorx/__init__.py
+++ b/connectorx-python/connectorx/__init__.py
@@ -185,10 +185,10 @@ def read_sql(
                 raise ValueError("You need to install polars first")
 
             try:
-                df = pl.DataFrame.from_arrow(df)
-            except AttributeError:
                 # api change for polars >= 0.8.*
                 df = pl.from_arrow(df)
+            except AttributeError:
+                df = pl.DataFrame.from_arrow(df)
         return df
 
     if isinstance(query, str):
@@ -256,7 +256,7 @@ def read_sql(
 
         result = _read_sql(
             conn,
-            "arrow" if return_type in {"arrow", "polars"} else "arrow2",
+            "arrow2" if return_type in {"arrow2", "polars", "polars2"} else "arrow",
             queries=queries,
             protocol=protocol,
             partition_query=partition_query,


### PR DESCRIPTION
Hi! This PR is mostly about compatibility with Polars.
With this, using `return_type="polars"` will have the same result as `polars.from_sql`

Both Polars itself and their integration with this lib uses Arrow2.

Reference to the integration: https://github.com/pola-rs/polars/blob/9dabbe5b4d0d21a65bf6e2a52062175485603a86/py-polars/polars/io.py#L1096

Also, for the from_arrow function, I believe testing the current API and then falling back to the old one should be preferable. But I can remove this from the PR if you disagree.