### PR TITLE
Add PG JSON to Arrow transport rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,9 +2255,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3296,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d24607049214c5e42d3df53ac1d8a23c34cc6a5eefe3122acb2c72174719959"
+checksum = "6fdc8e4da70586127893be32b7adf21326a4c6b1aba907611edf467d13ffe895"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -3528,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.25.4"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
 dependencies = [
  "bitflags",
  "chrono",

--- a/connectorx/Cargo.toml
+++ b/connectorx/Cargo.toml
@@ -46,7 +46,7 @@ r2d2_mysql = {version = "21.0", optional = true}
 r2d2_postgres = {version = "0.18.1", optional = true}
 r2d2_sqlite = {version = "0.18", optional = true}
 regex = {version = "1", optional = true}
-rusqlite = {version = "0.25", features = ["column_decltype", "chrono", "bundled"], optional = true}
+rusqlite = {version = "0.26.2", features = ["column_decltype", "chrono", "bundled"], optional = true}
 rust_decimal = {version = "1", features = ["db-postgres"], optional = true}
 rust_decimal_macros = {version = "1", optional = true}
 tiberius = {version = "0.5", features = ["rust_decimal", "chrono"], optional = true}

--- a/connectorx/Cargo.toml
+++ b/connectorx/Cargo.toml
@@ -44,9 +44,9 @@ r2d2 = {version = "0.8", optional = true}
 r2d2-oracle = {version = "0.5.0", features = ["chrono"], optional = true}
 r2d2_mysql = {version = "21.0", optional = true}
 r2d2_postgres = {version = "0.18.1", optional = true}
-r2d2_sqlite = {version = "0.18", optional = true}
+r2d2_sqlite = {version = "0.20.0", optional = true}
 regex = {version = "1", optional = true}
-rusqlite = {version = "0.26.2", features = ["column_decltype", "chrono", "bundled"], optional = true}
+rusqlite = {version = "0.27.0", features = ["column_decltype", "chrono", "bundled"], optional = true}
 rust_decimal = {version = "1", features = ["db-postgres"], optional = true}
 rust_decimal_macros = {version = "1", optional = true}
 tiberius = {version = "0.5", features = ["rust_decimal", "chrono"], optional = true}

--- a/connectorx/src/destinations/arrow/arrow_assoc.rs
+++ b/connectorx/src/destinations/arrow/arrow_assoc.rs
@@ -3,7 +3,7 @@ use crate::constants::SECONDS_IN_DAY;
 use arrow::array::{
     ArrayBuilder, BooleanBuilder, Date32Builder, Date64Builder, Float32Builder, Float64Builder,
     Int32Builder, Int64Builder, LargeBinaryBuilder, StringBuilder, Time64NanosecondBuilder,
-    UInt32Builder, UInt64Builder,
+    TimestampNanosecondBuilder, UInt32Builder, UInt64Builder,
 };
 use arrow::datatypes::Field;
 use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
@@ -140,34 +140,44 @@ impl ArrowAssoc for Option<String> {
 }
 
 impl ArrowAssoc for DateTime<Utc> {
-    type Builder = Float64Builder;
+    type Builder = TimestampNanosecondBuilder;
 
-    fn builder(_nrows: usize) -> Float64Builder {
-        unimplemented!()
+    fn builder(nrows: usize) -> Self::Builder {
+        TimestampNanosecondBuilder::with_capacity(nrows)
     }
 
-    fn append(_builder: &mut Self::Builder, _value: DateTime<Utc>) -> Result<()> {
-        unimplemented!()
+    #[throws(ArrowDestinationError)]
+    fn append(builder: &mut Self::Builder, value: DateTime<Utc>) {
+        builder.append_value(value.timestamp_nanos())
     }
 
-    fn field(_header: &str) -> Field {
-        unimplemented!()
+    fn field(header: &str) -> Field {
+        Field::new(
+            header,
+            ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".to_string())),
+            true,
+        )
     }
 }
 
 impl ArrowAssoc for Option<DateTime<Utc>> {
-    type Builder = Float64Builder;
+    type Builder = TimestampNanosecondBuilder;
 
-    fn builder(_nrows: usize) -> Float64Builder {
-        unimplemented!()
+    fn builder(nrows: usize) -> Self::Builder {
+        TimestampNanosecondBuilder::with_capacity(nrows)
     }
 
-    fn append(_builder: &mut Self::Builder, _value: Option<DateTime<Utc>>) -> Result<()> {
-        unimplemented!()
+    #[throws(ArrowDestinationError)]
+    fn append(builder: &mut Self::Builder, value: Option<DateTime<Utc>>) {
+        builder.append_option(value.map(|x| x.timestamp_nanos()))
     }
 
-    fn field(_header: &str) -> Field {
-        unimplemented!()
+    fn field(header: &str) -> Field {
+        Field::new(
+            header,
+            ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".to_string())),
+            false,
+        )
     }
 }
 

--- a/connectorx/src/destinations/arrow/arrow_assoc.rs
+++ b/connectorx/src/destinations/arrow/arrow_assoc.rs
@@ -154,7 +154,7 @@ impl ArrowAssoc for DateTime<Utc> {
     fn field(header: &str) -> Field {
         Field::new(
             header,
-            ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".to_string())),
+            ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
             true,
         )
     }
@@ -175,7 +175,7 @@ impl ArrowAssoc for Option<DateTime<Utc>> {
     fn field(header: &str) -> Field {
         Field::new(
             header,
-            ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".to_string())),
+            ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
             false,
         )
     }

--- a/connectorx/src/sources/sqlite/mod.rs
+++ b/connectorx/src/sources/sqlite/mod.rs
@@ -90,7 +90,7 @@ where
             let l1query = limit1_query(query, &SQLiteDialect {})?;
 
             let is_sucess = conn.query_row(l1query.as_str(), [], |row| {
-                for (j, col) in row.columns().iter().enumerate() {
+                for (j, col) in row.as_ref().columns().iter().enumerate() {
                     if j >= names.len() {
                         names.push(col.name().to_string());
                     }
@@ -142,14 +142,15 @@ where
         }
 
         // tried all queries but all get empty result set
-        let mut stmt = conn.prepare(self.queries[0].as_str())?;
-        let rows = stmt.query([])?;
+        let stmt = conn.prepare(self.queries[0].as_str())?;
 
-        if let Some(cnames) = rows.column_names() {
-            self.names = cnames.into_iter().map(|s| s.to_string()).collect();
-            // set all columns as string (align with pandas)
-            self.schema = vec![SQLiteTypeSystem::Text(false); self.names.len()];
-        }
+        self.names = stmt
+            .column_names()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+        // set all columns as string (align with pandas)
+        self.schema = vec![SQLiteTypeSystem::Text(false); self.names.len()];
     }
 
     #[throws(SQLiteSourceError)]

--- a/connectorx/src/transports/postgres_arrow.rs
+++ b/connectorx/src/transports/postgres_arrow.rs
@@ -13,6 +13,7 @@ use num_traits::ToPrimitive;
 use postgres::NoTls;
 use postgres_openssl::MakeTlsConnector;
 use rust_decimal::Decimal;
+use serde_json::Value;
 use std::marker::PhantomData;
 use thiserror::Error;
 use uuid::Uuid;
@@ -57,6 +58,8 @@ macro_rules! impl_postgres_transport {
                 { UUID[Uuid]                 => LargeUtf8[String]         | conversion option }
                 { Char[&'r str]              => LargeUtf8[String]         | conversion none }
                 { ByteA[Vec<u8>]             => LargeBinary[Vec<u8>]      | conversion auto }
+                { JSON[Value]                => LargeUtf8[String]         | conversion option }
+                { JSONB[Value]               => LargeUtf8[String]         | conversion none }
             }
         );
     }
@@ -81,5 +84,11 @@ impl<P, C> TypeConversion<Decimal, f64> for PostgresArrowTransport<P, C> {
     fn convert(val: Decimal) -> f64 {
         val.to_f64()
             .unwrap_or_else(|| panic!("cannot convert decimal {:?} to float64", val))
+    }
+}
+
+impl<P, C> TypeConversion<Value, String> for PostgresArrowTransport<P, C> {
+    fn convert(val: Value) -> String {
+        val.to_string()
     }
 }


### PR DESCRIPTION
There are a couple of (related) changes in this PR, all of which underpin the [remote table](https://seafowl.io/docs/guides/remote-tables) functionality that we've recently built on Seafowl: 

- the JSON transport mappings just align the existing implementation in Arrow 2 with the missing one in Arrow.
- likewise, the missing arrow association rules for `DateTime<Utc>` and `Option<DateTime<Utc>>` (PG Timestampz type) are added. Unlike in Arrow 2, we don't have a builder that will collect the Timestamp values with a UTC zone set, so we have to set it to `None` instead.
- finally bump sqlite related libs, and fix resulting conflicts (`columns` and `column_names` function changes).

Basically, we use these changes on our connector-x fork, but given that they are pretty general it may be useful to contribute them upstream.