### PR TITLE
Fixed oracle date type to rust naive datetime - issue 469

### DIFF
--- a/connectorx/src/sources/oracle/typesystem.rs
+++ b/connectorx/src/sources/oracle/typesystem.rs
@@ -14,7 +14,6 @@ pub enum OracleTypeSystem {
     Char(bool),
     NVarChar(bool),
     NChar(bool),
-    Date(bool),
     Timestamp(bool),
     TimestampTz(bool),
 }
@@ -26,7 +25,7 @@ impl_typesystem! {
         { Float | NumFloat | BinaryFloat | BinaryDouble => f64 }
         { Blob => Vec<u8>}
         { Clob | VarChar | Char | NVarChar | NChar => String }
-        { Date => NaiveDate }
+        { Date => NaiveDateTime }
         { Timestamp => NaiveDateTime }
         { TimestampTz => DateTime<Utc> }
     }
@@ -48,7 +47,7 @@ impl<'a> From<&'a OracleType> for OracleTypeSystem {
             OracleType::NChar(_) => NChar(true),
             OracleType::Varchar2(_) => VarChar(true),
             OracleType::NVarchar2(_) => NVarChar(true),
-            OracleType::Date => Date(true),
+            OracleType::Date => Timestamp(true),
             OracleType::Timestamp(_) => Timestamp(true),
             OracleType::TimestampTZ(_) => TimestampTz(true),
             _ => unimplemented!("{}", format!("Type {:?} not implemented for oracle!", ty)),


### PR DESCRIPTION
Oracle date type is more like a timestamp, to fix the problems listed on the issue https://github.com/sfu-db/connector-x/issues/469 I altered the Oracle `typesystem.rs` file.