### PR TITLE
Libgssapi

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev libkrb5-dev libclang-dev
         env:
           DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66
+          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev libclang-dev
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python
@@ -181,7 +181,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66 libkrb5-dev libclang-dev
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28 --features integrated-auth-gssapi
         env:
           SQLITE3_STATIC: 1
 
@@ -61,7 +61,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28 --features integrated-auth-gssapi
         env:
           SQLITE3_STATIC: 1
 
@@ -69,7 +69,7 @@ jobs:
       #   with:
       #     maturin-version: v0.14.15
       #     command: build
-      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --release --manylinux 2_28
+      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --release --manylinux 2_28 --features integrated-auth-gssapi
       #   env:
       #     SQLITE3_STATIC: 1
 
@@ -84,6 +84,9 @@ jobs:
       matrix:
         os: ["windows-latest", "macos-10.15"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        include:
+          - os: "macos-10.15"
+            features: "--features integrated-auth-gssapi"
     steps:
       - uses: actions/checkout@v2
 
@@ -117,7 +120,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release
+          args: -m connectorx-python/Cargo.toml -i python --release ${{ matrix.features }}
         env:
           SQLITE3_STATIC: 1
 
@@ -131,7 +134,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release
+          args: -m connectorx-python/Cargo.toml -i python --release ${{ matrix.features }}
         env:
           SQLITE3_STATIC: 1
 
@@ -178,7 +181,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release  --features integrated-auth-gssapi
         env:
           SQLITE3_STATIC: 1
 
@@ -192,7 +195,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release  --features integrated-auth-gssapi
         env:
           SQLITE3_STATIC: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64
     strategy:
       matrix:
         python-version: [[38, "3.8"], [39, "3.9"], [310, "3.10"], [311, "3.11"]]
@@ -18,11 +18,7 @@ jobs:
 
       - name: Set python version
         run: |
-          if [[ "${{ matrix.python-version[0] }}" == "37" ]]; then
-            echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
-          else
-            echo "/opt/python/cp${{ matrix.python-version[0] }}-cp${{ matrix.python-version[0] }}/bin" >> $GITHUB_PATH
-          fi
+          echo "/opt/python/cp${{ matrix.python-version[0] }}-cp${{ matrix.python-version[0] }}/bin" >> $GITHUB_PATH
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -39,18 +35,19 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel
+          yum install -y epel-release
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs clang-devel
 
       - name: Setup project
         run: |
           just bootstrap-python
 
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release --manylinux 2014
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28
         env:
           SQLITE3_STATIC: 1
 
@@ -59,20 +56,20 @@ jobs:
           cp -rf connectorx-python/target/release/jassets connectorx-python/connectorx/dependencies
 
       # rebuild the wheel to incorporate j4rs dependencies
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release --manylinux 2014
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28
         env:
           SQLITE3_STATIC: 1
 
-      # - uses: messense/maturin-action@v1
+      # - uses: PyO3/maturin-action@v1
       #   with:
-      #     maturin-version: v0.12.1
+      #     maturin-version: v0.14.15
       #     command: build
-      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --no-sdist --release --manylinux 2014
+      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --release --manylinux 2_28
       #   env:
       #     SQLITE3_STATIC: 1
 
@@ -115,12 +112,12 @@ jobs:
         run: |
           just bootstrap-python
 
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release
+          args: -m connectorx-python/Cargo.toml -i python --release
         env:
           SQLITE3_STATIC: 1
 
@@ -129,12 +126,12 @@ jobs:
           cp -r connectorx-python/target/release/jassets connectorx-python/connectorx/dependencies
 
       # rebuild the wheel to incorporate j4rs dependencies
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release
+          args: -m connectorx-python/Cargo.toml -i python --release
         env:
           SQLITE3_STATIC: 1
 
@@ -176,12 +173,12 @@ jobs:
         run: |
           just bootstrap-python
 
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --no-sdist --release
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release
         env:
           SQLITE3_STATIC: 1
 
@@ -190,12 +187,12 @@ jobs:
           cp -rf connectorx-python/target/aarch64-apple-darwin/release/jassets connectorx-python/connectorx/dependencies
 
       # rebuild the wheel to incorporate j4rs dependencies
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --no-sdist --release
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release
         env:
           SQLITE3_STATIC: 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4260,6 +4260,7 @@ dependencies = [
  "futures",
  "futures-sink",
  "futures-util",
+ "libgssapi",
  "num-traits",
  "once_cell",
  "opentls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,14 +434,18 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
+ "clap",
+ "env_logger",
  "lazy_static",
  "lazycell",
+ "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "which",
 ]
 
 [[package]]
@@ -733,9 +746,13 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
+ "ansi_term",
+ "atty",
  "bitflags",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -810,6 +827,7 @@ dependencies = [
  "iai",
  "itertools",
  "j4rs",
+ "libgssapi",
  "log",
  "mysql_common",
  "native-tls",
@@ -1112,7 +1130,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -2239,6 +2257,28 @@ name = "libc"
 version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+
+[[package]]
+name = "libgssapi"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "724dbcd1f871da9c67983537a47ac510c278656f6392418ad67c7a52720e54b2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "lazy_static",
+ "libgssapi-sys",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
+name = "libgssapi-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd7d65e409c889f6c9d81ff079371d0d8fd88d7dca702ff187ef96fb0450fb7"
+dependencies = [
+ "bindgen",
+]
 
 [[package]]
 name = "libloading"
@@ -4034,6 +4074,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -4472,7 +4518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -4562,6 +4608,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -4701,6 +4753,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,6 @@ dependencies = [
  "iai",
  "itertools",
  "j4rs",
- "libgssapi",
  "log",
  "mysql_common",
  "native-tls",

--- a/connectorx-python/Cargo.lock
+++ b/connectorx-python/Cargo.lock
@@ -75,6 +75,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,14 +434,18 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
+ "clap",
+ "env_logger",
  "lazy_static",
  "lazycell",
+ "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "which",
 ]
 
 [[package]]
@@ -767,9 +780,13 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
+ "ansi_term",
+ "atty",
  "bitflags",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -1184,7 +1201,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -2351,6 +2368,28 @@ name = "libc"
 version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+
+[[package]]
+name = "libgssapi"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "724dbcd1f871da9c67983537a47ac510c278656f6392418ad67c7a52720e54b2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "lazy_static",
+ "libgssapi-sys",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
+name = "libgssapi-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd7d65e409c889f6c9d81ff079371d0d8fd88d7dca702ff187ef96fb0450fb7"
+dependencies = [
+ "bindgen",
+]
 
 [[package]]
 name = "libloading"
@@ -4323,6 +4362,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -4503,6 +4548,7 @@ dependencies = [
  "futures",
  "futures-sink",
  "futures-util",
+ "libgssapi",
  "num-traits",
  "once_cell",
  "opentls",
@@ -4857,6 +4903,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/connectorx-python/Cargo.toml
+++ b/connectorx-python/Cargo.toml
@@ -76,3 +76,4 @@ srcs = [
   "connectorx/src_oracle",
   "connectorx/src_bigquery",
 ]
+integrated-auth-gssapi = ["connectorx/integrated-auth-gssapi"]

--- a/connectorx/Cargo.toml
+++ b/connectorx/Cargo.toml
@@ -58,6 +58,9 @@ uuid = {version = "0.8", optional = true}
 j4rs = {version = "0.13", optional = true}
 datafusion = {version = "14", optional = true}
 
+[target.'cfg(unix)'.dependencies]
+libgssapi = { version = "0.4.5", optional = true, default-features = false }
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 name = "connectorx"
@@ -69,7 +72,7 @@ iai = "0.1"
 pprof = {version = "0.5", features = ["flamegraph"]}
 
 [features]
-all = ["src_sqlite", "src_postgres", "src_mysql", "src_mssql", "src_oracle", "src_bigquery", "src_csv", "src_dummy", "dst_arrow", "dst_arrow2", "federation", "fed_exec"]
+all = ["src_sqlite", "src_postgres", "src_mysql", "src_mssql", "src_oracle", "src_bigquery", "src_csv", "src_dummy", "dst_arrow", "dst_arrow2", "federation", "fed_exec", "integrated-auth-gssapi"]
 branch = []
 default = ["fptr"]
 dst_arrow = ["arrow"]
@@ -99,5 +102,6 @@ src_postgres = [
 src_sqlite = ["rusqlite", "r2d2_sqlite", "fallible-streaming-iterator", "r2d2", "urlencoding"]
 federation = ["j4rs"]
 fed_exec = ["datafusion", "tokio"]
+integrated-auth-gssapi = ["libgssapi"]
 [package.metadata.docs.rs]
 features = ["all"]

--- a/connectorx/Cargo.toml
+++ b/connectorx/Cargo.toml
@@ -50,7 +50,7 @@ regex = {version = "1", optional = true}
 rusqlite = {version = "0.27.0", features = ["column_decltype", "chrono", "bundled"], optional = true}
 rust_decimal = {version = "1", features = ["db-postgres"], optional = true}
 rust_decimal_macros = {version = "1", optional = true}
-tiberius = {version = "0.5", features = ["rust_decimal", "chrono"], optional = true}
+tiberius = {version = "0.5", features = ["rust_decimal", "chrono", "integrated-auth-gssapi"], optional = true}
 tokio = {version = "1", features = ["rt", "rt-multi-thread", "net"], optional = true}
 tokio-util = {version = "0.6", optional = true}
 urlencoding = {version = "2.1", optional = true}

--- a/connectorx/Cargo.toml
+++ b/connectorx/Cargo.toml
@@ -58,9 +58,6 @@ uuid = {version = "0.8", optional = true}
 j4rs = {version = "0.13", optional = true}
 datafusion = {version = "14", optional = true}
 
-[target.'cfg(unix)'.dependencies]
-libgssapi = { version = "0.4.5", optional = true, default-features = false }
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 name = "connectorx"
@@ -72,7 +69,7 @@ iai = "0.1"
 pprof = {version = "0.5", features = ["flamegraph"]}
 
 [features]
-all = ["src_sqlite", "src_postgres", "src_mysql", "src_mssql", "src_oracle", "src_bigquery", "src_csv", "src_dummy", "dst_arrow", "dst_arrow2", "federation", "fed_exec", "integrated-auth-gssapi"]
+all = ["src_sqlite", "src_postgres", "src_mysql", "src_mssql", "src_oracle", "src_bigquery", "src_csv", "src_dummy", "dst_arrow", "dst_arrow2", "federation", "fed_exec"]
 branch = []
 default = ["fptr"]
 dst_arrow = ["arrow"]
@@ -102,6 +99,7 @@ src_postgres = [
 src_sqlite = ["rusqlite", "r2d2_sqlite", "fallible-streaming-iterator", "r2d2", "urlencoding"]
 federation = ["j4rs"]
 fed_exec = ["datafusion", "tokio"]
-integrated-auth-gssapi = ["libgssapi"]
+integrated-auth-gssapi = ["tiberius/integrated-auth-gssapi"]
+
 [package.metadata.docs.rs]
 features = ["all"]

--- a/connectorx/src/sources/mssql/mod.rs
+++ b/connectorx/src/sources/mssql/mod.rs
@@ -63,7 +63,7 @@ pub fn mssql_config(url: &Url) -> Config {
     // Using SQL Server authentication.
     #[allow(unused)]
     let params: HashMap<String, String> = url.query_pairs().into_owned().collect();
-    #[cfg(any(windows,feature = "integrated-auth-gssapi"))]
+    #[cfg(any(windows, feature = "integrated-auth-gssapi"))]
     match params.get("trusted_connection") {
         // pefer trusted_connection if set to true
         Some(v) if v == "true" => {
@@ -78,7 +78,7 @@ pub fn mssql_config(url: &Url) -> Config {
             ));
         }
     };
-    #[cfg(all(not(windows),not(feature = "integrated-auth-gssapi")))]
+    #[cfg(all(not(windows), not(feature = "integrated-auth-gssapi")))]
     config.authentication(AuthMethod::sql_server(
         decode(url.username())?.to_owned(),
         decode(url.password().unwrap_or(""))?.to_owned(),

--- a/connectorx/src/sources/mssql/mod.rs
+++ b/connectorx/src/sources/mssql/mod.rs
@@ -63,7 +63,7 @@ pub fn mssql_config(url: &Url) -> Config {
     // Using SQL Server authentication.
     #[allow(unused)]
     let params: HashMap<String, String> = url.query_pairs().into_owned().collect();
-    #[cfg_attr(any(target_os = "windows", feature = "integrated-auth-gssapi"))]
+    #[cfg(any(windows,feature = "integrated-auth-gssapi"))]
     match params.get("trusted_connection") {
         // pefer trusted_connection if set to true
         Some(v) if v == "true" => {
@@ -78,7 +78,7 @@ pub fn mssql_config(url: &Url) -> Config {
             ));
         }
     };
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows),not(feature = "integrated-auth-gssapi")))]
     config.authentication(AuthMethod::sql_server(
         decode(url.username())?.to_owned(),
         decode(url.password().unwrap_or(""))?.to_owned(),

--- a/connectorx/src/sources/mssql/mod.rs
+++ b/connectorx/src/sources/mssql/mod.rs
@@ -63,7 +63,7 @@ pub fn mssql_config(url: &Url) -> Config {
     // Using SQL Server authentication.
     #[allow(unused)]
     let params: HashMap<String, String> = url.query_pairs().into_owned().collect();
-    #[cfg(windows)]
+    #[cfg_attr(any(target_os = "windows", feature = "integrated-auth-gssapi"))]
     match params.get("trusted_connection") {
         // pefer trusted_connection if set to true
         Some(v) if v == "true" => {

--- a/scripts/python-helper.py
+++ b/scripts/python-helper.py
@@ -61,7 +61,7 @@ def main() -> None:
             else:
                 abitag = pyver
         elif METADATA["platform"] == "linux":
-            arch = "manylinux2014_x86_64"
+            arch = "manylinux_2_28_x86_64"
             abitag = METADATA["abi_tag"]
         elif METADATA["platform"] == "darwin":
             arch = "macosx_10_15_intel"


### PR DESCRIPTION
The Tiberius connector's `AuthMethod::Integrated` means AD on windows, but it means kerberos on *nix. If libgssapi is installed, then you might want to use this auth method. This is a common set up in orgs which mostly use Windows and disallow SA auth. Kerberos is the only way to connect to the MSSQL server from linux. The `#[cfg(windows)]` meant that if you tried to use kerberos from a *nix client to connect to a MSSQL db with tiberius, you'd get a rather cryptic error message. For instance

```import connectorx as cx

con_str = f"mssql://some.db.url:1433/encrypt=true&trusted_execution=true"

query = "SELECT * FROM Table

cx.read_sql(con_str,query)
```

errors out with 

`Login failed for user ''. code=18456`

when run on linux. 

This PR fixes that issue.