### PR TITLE
Fixed oracle Date type conversion to fix issue #469

### DIFF
--- a/connectorx-python/src/pandas/transports/oracle.rs
+++ b/connectorx-python/src/pandas/transports/oracle.rs
@@ -1,7 +1,7 @@
 use crate::errors::ConnectorXPythonError;
 use crate::pandas::destination::PandasDestination;
 use crate::pandas::typesystem::PandasTypeSystem;
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use connectorx::{
     impl_transport,
     sources::oracle::{OracleSource, OracleTypeSystem},
@@ -27,17 +27,11 @@ impl_transport!(
         { Char[String]               => String[String]          | conversion none }
         { NVarChar[String]           => String[String]          | conversion none }
         { NChar[String]              => String[String]          | conversion none }
-        { Date[NaiveDate]            => DateTime[DateTime<Utc>] | conversion option }
-        { Timestamp[NaiveDateTime]   => DateTime[DateTime<Utc>] | conversion option }
+        { Date[NaiveDateTime]        => DateTime[DateTime<Utc>] | conversion option }
+        { Timestamp[NaiveDateTime]   => DateTime[DateTime<Utc>] | conversion none }
         { TimestampTz[DateTime<Utc>] => DateTime[DateTime<Utc>] | conversion auto }
     }
 );
-
-impl<'py> TypeConversion<NaiveDate, DateTime<Utc>> for OraclePandasTransport<'py> {
-    fn convert(val: NaiveDate) -> DateTime<Utc> {
-        DateTime::from_utc(val.and_hms(0, 0, 0), Utc)
-    }
-}
 
 impl<'py> TypeConversion<NaiveDateTime, DateTime<Utc>> for OraclePandasTransport<'py> {
     fn convert(val: NaiveDateTime) -> DateTime<Utc> {

--- a/connectorx/src/sources/oracle/typesystem.rs
+++ b/connectorx/src/sources/oracle/typesystem.rs
@@ -14,7 +14,6 @@ pub enum OracleTypeSystem {
     Char(bool),
     NVarChar(bool),
     NChar(bool),
-    Date(bool),
     Timestamp(bool),
     TimestampTz(bool),
 }
@@ -26,7 +25,7 @@ impl_typesystem! {
         { Float | NumFloat | BinaryFloat | BinaryDouble => f64 }
         { Blob => Vec<u8>}
         { Clob | VarChar | Char | NVarChar | NChar => String }
-        { Date => NaiveDate }
+        { Date => NaiveDateTime }
         { Timestamp => NaiveDateTime }
         { TimestampTz => DateTime<Utc> }
     }
@@ -48,7 +47,7 @@ impl<'a> From<&'a OracleType> for OracleTypeSystem {
             OracleType::NChar(_) => NChar(true),
             OracleType::Varchar2(_) => VarChar(true),
             OracleType::NVarchar2(_) => NVarChar(true),
-            OracleType::Date => Date(true),
+            OracleType::Date => Timestamp(true),
             OracleType::Timestamp(_) => Timestamp(true),
             OracleType::TimestampTZ(_) => TimestampTz(true),
             _ => unimplemented!("{}", format!("Type {:?} not implemented for oracle!", ty)),

--- a/connectorx/src/sources/oracle/typesystem.rs
+++ b/connectorx/src/sources/oracle/typesystem.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use r2d2_oracle::oracle::sql_type::OracleType;
 
 #[derive(Copy, Clone, Debug)]
@@ -14,6 +14,7 @@ pub enum OracleTypeSystem {
     Char(bool),
     NVarChar(bool),
     NChar(bool),
+    Date(bool),
     Timestamp(bool),
     TimestampTz(bool),
 }
@@ -25,8 +26,7 @@ impl_typesystem! {
         { Float | NumFloat | BinaryFloat | BinaryDouble => f64 }
         { Blob => Vec<u8>}
         { Clob | VarChar | Char | NVarChar | NChar => String }
-        { Date => NaiveDateTime }
-        { Timestamp => NaiveDateTime }
+        { Date | Timestamp => NaiveDateTime }
         { TimestampTz => DateTime<Utc> }
     }
 }
@@ -47,7 +47,7 @@ impl<'a> From<&'a OracleType> for OracleTypeSystem {
             OracleType::NChar(_) => NChar(true),
             OracleType::Varchar2(_) => VarChar(true),
             OracleType::NVarchar2(_) => NVarChar(true),
-            OracleType::Date => Timestamp(true),
+            OracleType::Date => Date(true),
             OracleType::Timestamp(_) => Timestamp(true),
             OracleType::TimestampTZ(_) => TimestampTz(true),
             _ => unimplemented!("{}", format!("Type {:?} not implemented for oracle!", ty)),

--- a/connectorx/src/transports/oracle_arrow.rs
+++ b/connectorx/src/transports/oracle_arrow.rs
@@ -4,7 +4,7 @@ use crate::{
     sources::oracle::{OracleSource, OracleSourceError, OracleTypeSystem},
     typesystem::TypeConversion,
 };
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -38,8 +38,8 @@ impl_transport!(
         { Char[String]               => LargeUtf8[String]          | conversion none }
         { NVarChar[String]           => LargeUtf8[String]          | conversion none }
         { NChar[String]              => LargeUtf8[String]          | conversion none }
-        { Date[NaiveDate]            => Date32[NaiveDate]          | conversion auto }
-        { Timestamp[NaiveDateTime]   => Date64[NaiveDateTime]      | conversion auto }
+        { Date[NaiveDateTime]        => Date64[NaiveDateTime]      | conversion auto }
+        { Timestamp[NaiveDateTime]   => Date64[NaiveDateTime]      | conversion none }
         { TimestampTz[DateTime<Utc>] => DateTimeTz[DateTime<Utc>]  | conversion auto }
     }
 );

--- a/connectorx/src/transports/oracle_arrow2.rs
+++ b/connectorx/src/transports/oracle_arrow2.rs
@@ -6,7 +6,7 @@ use crate::{
     sources::oracle::{OracleSource, OracleSourceError, OracleTypeSystem},
     typesystem::TypeConversion,
 };
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -40,8 +40,8 @@ impl_transport!(
         { Char[String]                  => LargeUtf8[String]            | conversion none }
         { NVarChar[String]              => LargeUtf8[String]            | conversion none }
         { NChar[String]                 => LargeUtf8[String]            | conversion none }
-        { Date[NaiveDate]               => Date32[NaiveDate]            | conversion auto }
-        { Timestamp[NaiveDateTime]      => Date64[NaiveDateTime]        | conversion auto }
+        { Date[NaiveDateTime]           => Date64[NaiveDateTime]        | conversion auto }
+        { Timestamp[NaiveDateTime]      => Date64[NaiveDateTime]        | conversion none }
         { TimestampTz[DateTime<Utc>]    => DateTimeTz[DateTime<Utc>]    | conversion auto }
     }
 );


### PR DESCRIPTION
Changes made to fix the issues mentioned in the issue #469 to make oracle date type conversion display day : hours.

Files changed:
        `connectorx-python/src/pandas/transports/oracle.rs`
        `connectorx/src/sources/oracle/typesystem.rs`
        `connectorx/src/transports/oracle_arrow.rs`
        `connectorx/src/transports/oracle_arrow2.rs`