### PR TITLE
Push empty vec on ArrowAssoc when Option is None to fix Postgres  _varchar can panic on Option.unwrap

### DIFF
--- a/connectorx/src/destinations/arrow2/arrow_assoc.rs
+++ b/connectorx/src/destinations/arrow2/arrow_assoc.rs
@@ -448,13 +448,19 @@ impl ArrowAssoc for Option<Vec<String>> {
     }
 
     fn push(builder: &mut Self::Builder, value: Self) {
-        let value = value.unwrap();
         let mut string_array: Vec<Option<String>> = vec![];
+        match value {
+            Some(value) => {
         for sub_value in value {
             string_array.push(Some(sub_value))
         }
 
-        builder.try_push(Some(string_array));
+                builder.try_push(Some(string_array)).unwrap();
+            }
+            None => {
+                builder.try_push(Some(string_array)).unwrap();
+            }
+        };
     }
 
     fn field(header: &str) -> Field {


### PR DESCRIPTION
Reading a varchar array can return error `thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value'`
I was not able to figure out what row in my database led to this error because its a large base, and this PR fixes the issue already. But it would be interesting to figure this out and add it as a test condition.

Fixes #489 