### PR TITLE
Feat/add support for  _text

### DIFF
--- a/connectorx/src/sources/postgres/typesystem.rs
+++ b/connectorx/src/sources/postgres/typesystem.rs
@@ -21,6 +21,7 @@ pub enum PostgresTypeSystem {
     Int4Array(bool),
     Int8Array(bool),
     VarcharArray(bool),
+    TextArray(bool),
     Date(bool),
     Char(bool),
     BpChar(bool),
@@ -52,7 +53,7 @@ impl_typesystem! {
         { Float4Array => Vec<f32> }
         { Float8Array => Vec<f64> }
         { NumericArray => Vec<Decimal> }
-        { VarcharArray => Vec<String>}
+        { VarcharArray | TextArray => Vec<String>}
         { Bool => bool }
         { Char => i8 }
         { Text | BpChar | VarChar | Enum => &'r str }
@@ -84,6 +85,7 @@ impl<'a> From<&'a Type> for PostgresTypeSystem {
             "_float8" => Float8Array(true),
             "_numeric" => NumericArray(true),
             "_varchar" => VarcharArray(true),
+            "_text" => TextArray(true),
             "bool" => Bool(true),
             "char" => Char(true),
             "text" | "citext" | "ltree" | "lquery" | "ltxtquery" => Text(true),

--- a/connectorx/src/transports/postgres_arrow2.rs
+++ b/connectorx/src/transports/postgres_arrow2.rs
@@ -67,7 +67,9 @@ macro_rules! impl_postgres_transport {
                 { Float4Array[Vec<f32>]             => Float64Array[Vec<f64>]      | conversion auto_vec }
                 { Float8Array[Vec<f64>]             => Float64Array[Vec<f64>]      | conversion auto }
                 { NumericArray[Vec<Decimal>]        => Float64Array[Vec<f64>]      | conversion option }
-                { VarcharArray[Vec<String>]        => Utf8Array[Vec<String>]      | conversion auto_vec }
+                { VarcharArray[Vec<String>]        => Utf8Array[Vec<String>]      | conversion none }
+                { TextArray[Vec<String>]        => Utf8Array[Vec<String>]      | conversion auto }
+
             }
         );
     }

--- a/connectorx/tests/test_polars.rs
+++ b/connectorx/tests/test_polars.rs
@@ -181,3 +181,46 @@ fn test_pg_pl_varchar_array() {
     println!("{:?}", df);
     assert_eq!(df, test_df);
 }
+
+#[test]
+fn test_pg_pl_text_array() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dburl = env::var("POSTGRES_URL").unwrap();
+
+    let queries = [CXQuery::naked("select test_textarray from test_types")];
+    let url = Url::parse(dburl.as_str()).unwrap();
+    let (config, _tls) = rewrite_tls_args(&url).unwrap();
+    let builder = PostgresSource::<BinaryProtocol, NoTls>::new(config, NoTls, 2).unwrap();
+    let mut destination = Arrow2Destination::new();
+    let dispatcher = Dispatcher::<_, _, PostgresArrow2Transport<BinaryProtocol, NoTls>>::new(
+        builder,
+        &mut destination,
+        &queries,
+        Some(format!("select * from test_types")),
+    );
+
+    dispatcher.run().expect("run dispatcher");
+
+    let s1 = Series::new("a", ["text1", "text2"]);
+    let s2 = Series::new(
+        "b",
+        [
+            "0123456789",
+            "abcdefghijklmnopqrstuvwxyz",
+            "!@#$%^&*()_-+=~`:;<>?/",
+        ],
+    );
+    let s3 = Series::new("c", ["", "  "]);
+    let empty_vec: Vec<&str> = vec![];
+    let s4 = Series::new("d", empty_vec);
+
+    let df: DataFrame = destination.polars().unwrap();
+    let test_df: DataFrame = df!(
+        "test_textarray" => &[s1,s2,s3,s4]
+    )
+    .unwrap();
+
+    println!("{:?}", df);
+    assert_eq!(df, test_df);
+}

--- a/scripts/postgres.sql
+++ b/scripts/postgres.sql
@@ -67,13 +67,14 @@ CREATE TABLE IF NOT EXISTS test_types(
     test_ltree ltree,
     test_lquery lquery,
     test_ltxtquery ltxtquery,
-    test_varchararray VARCHAR[]
+    test_varchararray VARCHAR[],
+    test_textarray TEXT[]
 );
 
-INSERT INTO test_types VALUES ('1970-01-01', '1970-01-01 00:00:01', '1970-01-01 00:00:01-00', 0, -9223372036854775808, NULL, NULL, 'a', 'a', NULL, '86b494cc-96b2-11eb-9298-3e22fbb9fe9d', '08:12:40', '1 year 2 months 3 days', '{"customer": "John Doe", "items": {"product": "Beer","qty": 6}}', '{"product": "Beer","qty": 6}', NULL, 'happy','{}', '{}', '{}', '{-1, 0, 1}', '{-1, 0, 1123}', '{-9223372036854775808, 9223372036854775807}', 'str_citext', 'A.B.C.D', '*.B.*', 'A & B*',ARRAY['str1','str2']);
-INSERT INTO test_types VALUES ('2000-02-28', '2000-02-28 12:00:10', '2000-02-28 12:00:10-04', 1, 0, 3.1415926535, 521.34, 'bb', 'b', 'bb', '86b49b84-96b2-11eb-9298-3e22fbb9fe9d', NULL, '2 weeks ago', '{"customer": "Lily Bush", "items": {"product": "Diaper","qty": 24}}', '{"product": "Diaper","qty": 24}', 'Здра́вствуйте', 'very happy', NULL, NULL, NULL, '{}', '{}', '{}', '', 'A.B.E', 'A.*', 'A | B','{"0123456789","abcdefghijklmnopqrstuvwxyz","!@#$%^&*()_-+=~`:;<>?/"}');
-INSERT INTO test_types VALUES ('2038-01-18', '2038-01-18 23:59:59', '2038-01-18 23:59:59+08', 2, 9223372036854775807, 2.71, '1e-130', 'ccc', NULL, 'c', '86b49c42-96b2-11eb-9298-3e22fbb9fe9d', '23:00:10', '3 months 2 days ago', '{"customer": "Josh William", "items": {"product": "Toy Car","qty": 1}}', '{"product": "Toy Car","qty": 1}', '', 'ecstatic', '{123.123}', '{-1e-307, 1e308}', '{521.34}', '{-32768, 32767}', '{-2147483648, 2147483647}', '{0}', 's', 'A', '*', 'A@',ARRAY['','  ']);
-INSERT INTO test_types VALUES (NULL, NULL, NULL, 3, NULL, 0.00, -1e-37, NULL, 'd', 'defghijklm', NULL, '18:30:00', '3 year', NULL, NULL, '😜', NULL, '{-1e-37, 1e37}', '{0.000234, -12.987654321}', '{0.12, 333.33, 22.22}', NULL, NULL, NULL, NULL, NULL, NULL, NULL,'{}');
+INSERT INTO test_types VALUES ('1970-01-01', '1970-01-01 00:00:01', '1970-01-01 00:00:01-00', 0, -9223372036854775808, NULL, NULL, 'a', 'a', NULL, '86b494cc-96b2-11eb-9298-3e22fbb9fe9d', '08:12:40', '1 year 2 months 3 days', '{"customer": "John Doe", "items": {"product": "Beer","qty": 6}}', '{"product": "Beer","qty": 6}', NULL, 'happy','{}', '{}', '{}', '{-1, 0, 1}', '{-1, 0, 1123}', '{-9223372036854775808, 9223372036854775807}', 'str_citext', 'A.B.C.D', '*.B.*', 'A & B*',ARRAY['str1','str2'],ARRAY['text1','text2']);
+INSERT INTO test_types VALUES ('2000-02-28', '2000-02-28 12:00:10', '2000-02-28 12:00:10-04', 1, 0, 3.1415926535, 521.34, 'bb', 'b', 'bb', '86b49b84-96b2-11eb-9298-3e22fbb9fe9d', NULL, '2 weeks ago', '{"customer": "Lily Bush", "items": {"product": "Diaper","qty": 24}}', '{"product": "Diaper","qty": 24}', 'Здра́вствуйте', 'very happy', NULL, NULL, NULL, '{}', '{}', '{}', '', 'A.B.E', 'A.*', 'A | B','{"0123456789","abcdefghijklmnopqrstuvwxyz","!@#$%^&*()_-+=~`:;<>?/"}','{"0123456789","abcdefghijklmnopqrstuvwxyz","!@#$%^&*()_-+=~`:;<>?/"}');
+INSERT INTO test_types VALUES ('2038-01-18', '2038-01-18 23:59:59', '2038-01-18 23:59:59+08', 2, 9223372036854775807, 2.71, '1e-130', 'ccc', NULL, 'c', '86b49c42-96b2-11eb-9298-3e22fbb9fe9d', '23:00:10', '3 months 2 days ago', '{"customer": "Josh William", "items": {"product": "Toy Car","qty": 1}}', '{"product": "Toy Car","qty": 1}', '', 'ecstatic', '{123.123}', '{-1e-307, 1e308}', '{521.34}', '{-32768, 32767}', '{-2147483648, 2147483647}', '{0}', 's', 'A', '*', 'A@',ARRAY['','  '],ARRAY['','  ']);
+INSERT INTO test_types VALUES (NULL, NULL, NULL, 3, NULL, 0.00, -1e-37, NULL, 'd', 'defghijklm', NULL, '18:30:00', '3 year', NULL, NULL, '😜', NULL, '{-1e-37, 1e37}', '{0.000234, -12.987654321}', '{0.12, 333.33, 22.22}', NULL, NULL, NULL, NULL, NULL, NULL, NULL,'{}','{}');
 
 CREATE OR REPLACE FUNCTION increment(i integer) RETURNS integer AS $$
     BEGIN


### PR DESCRIPTION
The goal of this PR is to extend support for the _text type as requested by a user within the issue: https://github.com/sfu-db/connector-x/issues/480. This issue centers around connectorx panicking when interacting with tables containing a text[] type.

To solve this, I added:

- a TextArray type in the various enums in connectorx/src/sources/postgres/typesystem.rs
- a mapping between TextArray and Utf8Array in connectorx/src/transports/postgres_arrow2.rs
- added _text/text[] data to scripts/postgres.sql
- added a test for _text/text[] compatibility with postgres/polars in connectorx/tests/test_polars.rs
