### PR TITLE
fix incorrect nullability for datetime type when writing to arrow

### DIFF
--- a/connectorx/src/destinations/arrow/arrow_assoc.rs
+++ b/connectorx/src/destinations/arrow/arrow_assoc.rs
@@ -155,7 +155,7 @@ impl ArrowAssoc for DateTime<Utc> {
         Field::new(
             header,
             ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
-            true,
+            false,
         )
     }
 }
@@ -176,7 +176,7 @@ impl ArrowAssoc for Option<DateTime<Utc>> {
         Field::new(
             header,
             ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
-            false,
+            true,
         )
     }
 }


### PR DESCRIPTION
It panics when I try to read nullable datetime fields, then I found this incorrect conversion.