### PR TITLE
update to `r2d2-oracle=0.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "r2d2-oracle"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca5358dca54423e557b30e7b5a6d950d3a442ab4a56cc916965030cead8b02b"
+checksum = "e592c29a9d04b2eb9aa5adc8775087200343b486efa8a374cb43a02f4269d67f"
 dependencies = [
  "oracle",
  "r2d2",

--- a/connectorx/Cargo.toml
+++ b/connectorx/Cargo.toml
@@ -42,7 +42,7 @@ postgres-native-tls = {version = "0.5", optional = true}
 postgres-openssl = {version = "0.5", optional = true}
 mysql_common = {version = "0.29", features = ["chrono"], optional = true}
 r2d2 = {version = "0.8", optional = true}
-r2d2-oracle = {version = "0.5.0", features = ["chrono"], optional = true}
+r2d2-oracle = {version = "0.6", features = ["chrono"], optional = true}
 r2d2_mysql = {version = "23", optional = true}
 r2d2_postgres = {version = "0.18.1", optional = true}
 r2d2_sqlite = {version = "0.22.0", optional = true}


### PR DESCRIPTION
this is the only published crate still depending on v0.5 and is probably the reason for a lot of the downloads of the old version.

note: if you were to enable dependabot updates on connector-x then this wouldn't have to be done manually.