### PR TITLE
 Infinite Postgres Bug #573 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.swp
+
 **/target
 .vscode
 connectorx-python/connectorx/*.so

--- a/connectorx/tests/test_postgres.rs
+++ b/connectorx/tests/test_postgres.rs
@@ -1,3 +1,5 @@
+use chrono::{NaiveDate, NaiveDateTime, DateTime, Utc};
+use rust_decimal::Decimal;
 use arrow::{
     array::{BooleanArray, Float64Array, Int64Array, StringArray},
     record_batch::RecordBatch,
@@ -5,7 +7,7 @@ use arrow::{
 use connectorx::{
     destinations::arrow::ArrowDestination,
     prelude::*,
-    sources::postgres::{rewrite_tls_args, BinaryProtocol, CSVProtocol, PostgresSource},
+    sources::postgres::{rewrite_tls_args, BinaryProtocol, CSVProtocol, PostgresSource, SimpleProtocol, CursorProtocol},
     sources::PartitionParser,
     sql::CXQuery,
     transports::PostgresArrowTransport,
@@ -148,6 +150,355 @@ fn test_postgres() {
     let result = destination.arrow().unwrap();
     verify_arrow_results(result);
 }
+
+#[test]
+fn test_csv_infinite_values_binary_proto_option() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dburl = env::var("POSTGRES_URL").unwrap();
+    #[derive(Debug, PartialEq)]
+    struct Row(Option<NaiveDate>, Option<NaiveDateTime>, Option<DateTime<Utc>>);
+
+    let url = Url::parse(dburl.as_str()).unwrap();
+    let (config, _tls) = rewrite_tls_args(&url).unwrap();
+    let mut source = PostgresSource::<BinaryProtocol, NoTls>::new(config, NoTls, 1).unwrap();
+    source.set_queries(&[CXQuery::naked("SELECT test_date, test_timestamp, test_timestamp_timezone FROM test_infinite_values")]);
+    source.fetch_metadata().unwrap();
+
+    let mut partitions = source.partition().unwrap();
+    assert!(partitions.len() == 1);
+    let mut partition = partitions.remove(0);
+    partition.result_rows().expect("run query");
+
+    assert_eq!(3, partition.nrows());
+    assert_eq!(3, partition.ncols());
+
+    let mut parser = partition.parser().unwrap();
+
+    let mut rows: Vec<Row> = Vec::new();
+    loop {
+        let (n, is_last) = parser.fetch_next().unwrap();
+        for _i in 0..n {
+            rows.push(Row(
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+            ));
+        }
+        if is_last {
+            break;
+        }
+    }
+    assert_eq!(
+        vec![
+            Row(Some(NaiveDate::MAX), Some(NaiveDateTime::MAX), Some(DateTime::<Utc>::MAX_UTC)),
+            Row(Some(NaiveDate::MIN), Some(NaiveDateTime::MIN), Some(DateTime::<Utc>::MIN_UTC)),
+            Row(None, None, None),
+        ],
+        rows
+    );
+}
+
+#[test]
+fn test_infinite_values_cursor_proto_option() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dburl = env::var("POSTGRES_URL").unwrap();
+    #[derive(Debug, PartialEq)]
+    struct Row(Option<NaiveDate>, Option<NaiveDateTime>, Option<DateTime<Utc>>);
+
+    let url = Url::parse(dburl.as_str()).unwrap();
+    let (config, _tls) = rewrite_tls_args(&url).unwrap();
+    let mut source = PostgresSource::<CursorProtocol, NoTls>::new(config, NoTls, 1).unwrap();
+    source.set_queries(&[CXQuery::naked("SELECT test_date, test_timestamp, test_timestamp_timezone FROM test_infinite_values")]);
+    source.fetch_metadata().unwrap();
+
+    let mut partitions = source.partition().unwrap();
+    assert!(partitions.len() == 1);
+    let mut partition = partitions.remove(0);
+    partition.result_rows().expect("run query");
+
+    assert_eq!(3, partition.nrows());
+    assert_eq!(3, partition.ncols());
+
+    let mut parser = partition.parser().unwrap();
+
+    let mut rows: Vec<Row> = Vec::new();
+    loop {
+        let (n, is_last) = parser.fetch_next().unwrap();
+        for _i in 0..n {
+            rows.push(Row(
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+            ));
+        }
+        if is_last {
+            break;
+        }
+    }
+    assert_eq!(
+        vec![
+            Row(Some(NaiveDate::MAX), Some(NaiveDateTime::MAX), Some(DateTime::<Utc>::MAX_UTC)),
+            Row(Some(NaiveDate::MIN), Some(NaiveDateTime::MIN), Some(DateTime::<Utc>::MIN_UTC)),
+            Row(None, None, None),
+        ],
+        rows
+    );
+}
+
+#[test]
+fn test_csv_infinite_values_cursor_proto() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dburl = env::var("POSTGRES_URL").unwrap();
+    #[derive(Debug, PartialEq)]
+    struct Row(NaiveDate, NaiveDateTime, DateTime<Utc>);
+
+    let url = Url::parse(dburl.as_str()).unwrap();
+    let (config, _tls) = rewrite_tls_args(&url).unwrap();
+    let mut source = PostgresSource::<CursorProtocol, NoTls>::new(config, NoTls, 1).unwrap();
+    source.set_queries(&[CXQuery::naked("SELECT test_date, test_timestamp, test_timestamp_timezone FROM test_infinite_values WHERE test_date IS NOT NULL")]);
+    source.fetch_metadata().unwrap();
+
+    let mut partitions = source.partition().unwrap();
+    assert!(partitions.len() == 1);
+    let mut partition = partitions.remove(0);
+    partition.result_rows().expect("run query");
+
+    assert_eq!(2, partition.nrows());
+    assert_eq!(3, partition.ncols());
+
+    let mut parser = partition.parser().unwrap();
+
+    let mut rows: Vec<Row> = Vec::new();
+    loop {
+        let (n, is_last) = parser.fetch_next().unwrap();
+        for _i in 0..n {
+            rows.push(Row(
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+            ));
+        }
+        if is_last {
+            break;
+        }
+    }
+    assert_eq!(
+        vec![
+            Row(NaiveDate::MAX, NaiveDateTime::MAX, DateTime::<Utc>::MAX_UTC),
+            Row(NaiveDate::MIN, NaiveDateTime::MIN, DateTime::<Utc>::MIN_UTC),
+        ],
+        rows
+    );
+}
+
+#[test]
+fn test_csv_infinite_values_simple_proto() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dburl = env::var("POSTGRES_URL").unwrap();
+    #[derive(Debug, PartialEq)]
+    struct Row(i32, NaiveDate, NaiveDateTime, Decimal, DateTime<Utc>);
+
+    let url = Url::parse(dburl.as_str()).unwrap();
+    let (config, _tls) = rewrite_tls_args(&url).unwrap();
+    let mut source = PostgresSource::<SimpleProtocol, NoTls>::new(config, NoTls, 1).unwrap();
+    source.set_queries(&[CXQuery::naked("select * from test_infinite_values WHERE test_date IS NOT NULL")]);
+    source.fetch_metadata().unwrap();
+
+    let mut partitions = source.partition().unwrap();
+    assert!(partitions.len() == 1);
+    let mut partition = partitions.remove(0);
+    partition.result_rows().expect("run query");
+
+    assert_eq!(2, partition.nrows());
+    assert_eq!(5, partition.ncols());
+
+    let mut parser = partition.parser().unwrap();
+
+    let mut rows: Vec<Row> = Vec::new();
+    loop {
+        let (n, is_last) = parser.fetch_next().unwrap();
+        for _i in 0..n {
+            rows.push(Row(
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+            ));
+        }
+        if is_last {
+            break;
+        }
+    }
+    assert_eq!(
+        vec![
+            Row(1, NaiveDate::MAX, NaiveDateTime::MAX, Decimal::MAX, DateTime::<Utc>::MAX_UTC),
+            Row(2, NaiveDate::MIN, NaiveDateTime::MIN, Decimal::MIN, DateTime::<Utc>::MIN_UTC),
+        ],
+        rows
+    );
+}
+
+#[test]
+fn test_csv_infinite_values_simple_proto_option() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dburl = env::var("POSTGRES_URL").unwrap();
+    #[derive(Debug, PartialEq)]
+    struct Row(i32, Option<NaiveDate>, Option<NaiveDateTime>, Option<Decimal>, Option<DateTime<Utc>>);
+
+    let url = Url::parse(dburl.as_str()).unwrap();
+    let (config, _tls) = rewrite_tls_args(&url).unwrap();
+    let mut source = PostgresSource::<SimpleProtocol, NoTls>::new(config, NoTls, 1).unwrap();
+    source.set_queries(&[CXQuery::naked("select * from test_infinite_values")]);
+    source.fetch_metadata().unwrap();
+
+    let mut partitions = source.partition().unwrap();
+    assert!(partitions.len() == 1);
+    let mut partition = partitions.remove(0);
+    partition.result_rows().expect("run query");
+
+    assert_eq!(3, partition.nrows());
+    assert_eq!(5, partition.ncols());
+
+    let mut parser = partition.parser().unwrap();
+
+    let mut rows: Vec<Row> = Vec::new();
+    loop {
+        let (n, is_last) = parser.fetch_next().unwrap();
+        for _i in 0..n {
+            rows.push(Row(
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+            ));
+        }
+        if is_last {
+            break;
+        }
+    }
+    assert_eq!(
+        vec![
+            Row(1, Some(NaiveDate::MAX), Some(NaiveDateTime::MAX), Some(Decimal::MAX), Some(DateTime::<Utc>::MAX_UTC)),
+            Row(2, Some(NaiveDate::MIN), Some(NaiveDateTime::MIN), Some(Decimal::MIN), Some(DateTime::<Utc>::MIN_UTC)),
+            Row(3, None, None, None, None, )
+        ],
+        rows
+    );
+}
+
+#[test]
+fn test_csv_infinite_values() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dburl = env::var("POSTGRES_URL").unwrap();
+    #[derive(Debug, PartialEq)]
+    struct Row(i32, NaiveDate, NaiveDateTime, Decimal, DateTime<Utc>);
+
+    let url = Url::parse(dburl.as_str()).unwrap();
+    let (config, _tls) = rewrite_tls_args(&url).unwrap();
+    let mut source = PostgresSource::<CSVProtocol, NoTls>::new(config, NoTls, 1).unwrap();
+    source.set_queries(&[CXQuery::naked("select * from test_infinite_values WHERE test_date IS NOT NULL")]);
+    source.fetch_metadata().unwrap();
+
+    let mut partitions = source.partition().unwrap();
+    assert!(partitions.len() == 1);
+    let mut partition = partitions.remove(0);
+    partition.result_rows().expect("run query");
+
+    assert_eq!(2, partition.nrows());
+    assert_eq!(5, partition.ncols());
+
+    let mut parser = partition.parser().unwrap();
+
+    let mut rows: Vec<Row> = Vec::new();
+    loop {
+        let (n, is_last) = parser.fetch_next().unwrap();
+        for _i in 0..n {
+            rows.push(Row(
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+            ));
+        }
+        if is_last {
+            break;
+        }
+    }
+    assert_eq!(
+        vec![
+            Row(1, NaiveDate::MAX, NaiveDateTime::MAX, Decimal::MAX, DateTime::<Utc>::MAX_UTC),
+            Row(2, NaiveDate::MIN, NaiveDateTime::MIN, Decimal::MIN, DateTime::<Utc>::MIN_UTC),
+        ],
+        rows
+    );
+}
+
+#[test]
+fn test_csv_infinite_values_option() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dburl = env::var("POSTGRES_URL").unwrap();
+    #[derive(Debug, PartialEq)]
+    struct Row(i32, Option<NaiveDate>, Option<NaiveDateTime>, Option<Decimal>, Option<DateTime<Utc>>);
+
+    let url = Url::parse(dburl.as_str()).unwrap();
+    let (config, _tls) = rewrite_tls_args(&url).unwrap();
+    let mut source = PostgresSource::<CSVProtocol, NoTls>::new(config, NoTls, 1).unwrap();
+    source.set_queries(&[CXQuery::naked("select * from test_infinite_values")]);
+    source.fetch_metadata().unwrap();
+
+    let mut partitions = source.partition().unwrap();
+    assert!(partitions.len() == 1);
+    let mut partition = partitions.remove(0);
+    partition.result_rows().expect("run query");
+
+    assert_eq!(3, partition.nrows());
+    assert_eq!(5, partition.ncols());
+
+    let mut parser = partition.parser().unwrap();
+
+    let mut rows: Vec<Row> = Vec::new();
+    loop {
+        let (n, is_last) = parser.fetch_next().unwrap();
+        for _i in 0..n {
+            rows.push(Row(
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+                parser.produce().unwrap(),
+            ));
+        }
+        if is_last {
+            break;
+        }
+    }
+    assert_eq!(
+        vec![
+            Row(1, Some(NaiveDate::MAX), Some(NaiveDateTime::MAX), Some(Decimal::MAX), Some(DateTime::<Utc>::MAX_UTC)),
+            Row(2, Some(NaiveDate::MIN), Some(NaiveDateTime::MIN), Some(Decimal::MIN), Some(DateTime::<Utc>::MIN_UTC)),
+            Row(3, None, None, None, None, )
+        ],
+        rows
+    );
+}
+
 
 #[test]
 fn test_postgres_csv() {

--- a/scripts/postgres.sql
+++ b/scripts/postgres.sql
@@ -1,6 +1,7 @@
 DROP TABLE IF EXISTS test_table;
 DROP TABLE IF EXISTS test_str;
 DROP TABLE IF EXISTS test_types;
+DROP TABLE IF EXISTS test_infinite_values;
 DROP TYPE IF EXISTS happiness;
 DROP EXTENSION IF EXISTS citext;
 DROP EXTENSION IF EXISTS ltree;
@@ -19,6 +20,19 @@ INSERT INTO test_table VALUES (0, 5, 'a', 3.1, NULL);
 INSERT INTO test_table VALUES (3, 7, 'b', 3, FALSE);
 INSERT INTO test_table VALUES (4, 9, 'c', 7.8, NULL);
 INSERT INTO test_table VALUES (1314, 2, NULL, -10, TRUE);
+
+CREATE TABLE IF NOT EXISTS test_infinite_values(
+    test_int INTEGER NOT NULL,
+    test_date DATE,
+	test_timestamp TIMESTAMP,
+	test_real REAL,
+	test_timestamp_timezone TIMESTAMP WITH TIME ZONE
+);
+
+INSERT INTO test_infinite_values VALUES (1, 'infinity'::DATE, 'infinity'::TIMESTAMP, 'infinity'::REAL, 'infinity'::TIMESTAMP);
+INSERT INTO test_infinite_values VALUES (2, '-infinity'::DATE, '-infinity'::TIMESTAMP, '-infinity'::REAL, '-infinity'::TIMESTAMP);
+INSERT INTO test_infinite_values VALUES (3,NULL, NULL, NULL, NULL);
+
 
 CREATE TABLE IF NOT EXISTS test_str(
     id INTEGER NOT NULL,


### PR DESCRIPTION
Fix for a bug with postgres implementation. In postgres many numeric/date data types can have infinite or negative infinite values. Currently when one of these values is selected in connector-x it results in a runtime panic error. This PR fixes this issue for 3 data type (datetime, date, and real).

Resolves Issue 572
