### PR TITLE
Feat/pg semicolon support

### DIFF
--- a/connectorx-python/connectorx/__init__.py
+++ b/connectorx-python/connectorx/__init__.py
@@ -206,6 +206,7 @@ def read_sql(
     """
     if isinstance(query, list) and len(query) == 1:
         query = query[0]
+        query = query.replace(";","")
 
     if isinstance(conn, dict):
         assert partition_on is None and isinstance(
@@ -214,6 +215,8 @@ def read_sql(
         assert (
             protocol is None
         ), "Federated query does not support specifying protocol for now"
+
+        query = query.replace(";","")
         result = _read_sql2(query, conn)
         df = reconstruct_arrow(result)
         if return_type == "pandas":
@@ -232,6 +235,7 @@ def read_sql(
         return df
 
     if isinstance(query, str):
+        query = query.replace(";","")
         if partition_on is None:
             queries = [query]
             partition_query = None
@@ -245,7 +249,7 @@ def read_sql(
             }
             queries = None
     elif isinstance(query, list):
-        queries = query
+        queries = [subquery.replace(";","") for subquery in query]
         partition_query = None
 
         if partition_on is not None:

--- a/connectorx-python/connectorx/__init__.py
+++ b/connectorx-python/connectorx/__init__.py
@@ -206,7 +206,8 @@ def read_sql(
     """
     if isinstance(query, list) and len(query) == 1:
         query = query[0]
-        query = query.replace(";","")
+        query = remove_ending_semicolon(query)
+
 
     if isinstance(conn, dict):
         assert partition_on is None and isinstance(
@@ -216,7 +217,8 @@ def read_sql(
             protocol is None
         ), "Federated query does not support specifying protocol for now"
 
-        query = query.replace(";","")
+        query = remove_ending_semicolon(query)
+
         result = _read_sql2(query, conn)
         df = reconstruct_arrow(result)
         if return_type == "pandas":
@@ -235,7 +237,9 @@ def read_sql(
         return df
 
     if isinstance(query, str):
-        query = query.replace(";","")
+
+        query = remove_ending_semicolon(query)
+
         if partition_on is None:
             queries = [query]
             partition_query = None
@@ -249,7 +253,7 @@ def read_sql(
             }
             queries = None
     elif isinstance(query, list):
-        queries = [subquery.replace(";","") for subquery in query]
+        queries = [remove_ending_semicolon(subquery) for subquery in query]
         partition_query = None
 
         if partition_on is not None:
@@ -381,3 +385,11 @@ def reconstruct_pandas(df_infos: Dict[str, Any]):
     )
     df = pd.DataFrame(block_manager)
     return df
+
+
+def remove_ending_semicolon(query: str) -> str:
+    if  query[-1] == ';':
+        query= list(query)
+        query.pop(-1)
+        query = "".join(query)
+    return query

--- a/connectorx-python/connectorx/tests/test_postgres.py
+++ b/connectorx-python/connectorx/tests/test_postgres.py
@@ -1151,3 +1151,29 @@ def test_postgres_semicolon_support_str_query(postgres_url: str) -> None:
         },
     )
     assert_frame_equal(df, expected, check_names=True)
+
+
+def test_postgres_semicolon_list_queries(postgres_url: str) -> None:
+        queries = [
+        "SELECT * FROM test_table WHERE test_int < 2;",
+        "SELECT * FROM test_table WHERE test_int >= 2;",
+    ]
+
+    df = read_sql(postgres_url, query=queries)
+
+    expected = pd.DataFrame(
+        index=range(6),
+        data={
+            "test_int": pd.Series([0, 1, 2, 3, 4, 1314], dtype="Int64"),
+            "test_nullint": pd.Series([5, 3, None, 7, 9, 2], dtype="Int64"),
+            "test_str": pd.Series(
+                ["a", "str1", "str2", "b", "c", None], dtype="object"
+            ),
+            "test_float": pd.Series([3.1, None, 2.2, 3, 7.8, -10], dtype="float64"),
+            "test_bool": pd.Series(
+                [None, True, False, False, None, True], dtype="boolean"
+            ),
+        },
+    )
+    df.sort_values(by="test_int", inplace=True, ignore_index=True)
+    assert_frame_equal(df, expected, check_names=True)

--- a/connectorx-python/connectorx/tests/test_postgres.py
+++ b/connectorx-python/connectorx/tests/test_postgres.py
@@ -1139,3 +1139,15 @@ def test_postgres_name_type(postgres_url: str) -> None:
         },
     )
     assert_frame_equal(df, expected, check_names=True)
+
+
+
+def test_postgres_semicolon_support_str_query(postgres_url: str) -> None:
+    query = "SELECT test_name FROM test_types;"
+    df = read_sql(postgres_url, query)
+    expected = pd.DataFrame(
+        data={
+            "test_name": pd.Series(["0", "21", "someName", "101203203-1212323-22131235"]),
+        },
+    )
+    assert_frame_equal(df, expected, check_names=True)

--- a/connectorx-python/connectorx/tests/test_postgres.py
+++ b/connectorx-python/connectorx/tests/test_postgres.py
@@ -1154,7 +1154,7 @@ def test_postgres_semicolon_support_str_query(postgres_url: str) -> None:
 
 
 def test_postgres_semicolon_list_queries(postgres_url: str) -> None:
-        queries = [
+    queries = [
         "SELECT * FROM test_table WHERE test_int < 2;",
         "SELECT * FROM test_table WHERE test_int >= 2;",
     ]


### PR DESCRIPTION
Implementing support for finishing postgres queries with a semicolon per this [issue](https://github.com/sfu-db/connector-x/issues/575).

Changes include:
     - replace statements to remove semicolon from query in connectorx-python/connectorx/__init__.py (read_sql)
     - Tests to confirm that command terminating semicolons are being removed.