### PR TITLE
feat: Added Option for Oracle Connector to use Alias w/ Params

### DIFF
--- a/connectorx/src/sources/oracle/mod.rs
+++ b/connectorx/src/sources/oracle/mod.rs
@@ -57,13 +57,13 @@ pub fn connect_oracle(conn: &Url) -> Connector {
     let user = decode(conn.username())?.into_owned();
     let password = decode(conn.password().unwrap_or(""))?.into_owned();
     let host = decode(conn.host_str().unwrap_or("localhost"))?.into_owned();
-    let port = conn.port().unwrap_or(1521);
 
     let params: HashMap<String, String> = conn.query_pairs().into_owned().collect();
 
     let conn_str = if params.get("alias").map_or(false, |v| v == "true") {
-        decode(conn.path())?.into_owned()
+        host.clone()
     } else {
+        let port = conn.port().unwrap_or(1521);
         let path = decode(conn.path())?.into_owned();
         format!("//{}:{}{}", host, port, path)
     };

--- a/connectorx/src/sources/oracle/mod.rs
+++ b/connectorx/src/sources/oracle/mod.rs
@@ -69,7 +69,7 @@ pub fn connect_oracle(conn: &Url) -> Connector {
     };
 
     let mut connector = oracle::Connector::new(user.as_str(), password.as_str(), conn_str.as_str());
-    if user.is_empty() && password.is_empty() && host == "localhost" {
+    if user.is_empty() && password.is_empty() {
         debug!("No username or password provided, assuming system auth.");
         connector.external_auth(true);
     }

--- a/connectorx/src/sources/oracle/mod.rs
+++ b/connectorx/src/sources/oracle/mod.rs
@@ -1,6 +1,8 @@
 mod errors;
 mod typesystem;
 
+use std::collections::HashMap;
+
 pub use self::errors::OracleSourceError;
 pub use self::typesystem::OracleTypeSystem;
 use crate::constants::{DB_BUFFER_SIZE, ORACLE_ARRAY_SIZE};
@@ -56,9 +58,16 @@ pub fn connect_oracle(conn: &Url) -> Connector {
     let password = decode(conn.password().unwrap_or(""))?.into_owned();
     let host = decode(conn.host_str().unwrap_or("localhost"))?.into_owned();
     let port = conn.port().unwrap_or(1521);
-    let path = decode(conn.path())?.into_owned();
 
-    let conn_str = format!("//{}:{}{}", host, port, path);
+    let params: HashMap<String, String> = conn.query_pairs().into_owned().collect();
+
+    let conn_str = if params.get("alias").map_or(false, |v| v == "true") {
+        decode(conn.path())?.into_owned()
+    } else {
+        let path = decode(conn.path())?.into_owned();
+        format!("//{}:{}{}", host, port, path)
+    };
+
     let mut connector = oracle::Connector::new(user.as_str(), password.as_str(), conn_str.as_str());
     if user.is_empty() && password.is_empty() && host == "localhost" {
         debug!("No username or password provided, assuming system auth.");

--- a/docs/databases/oracle.md
+++ b/docs/databases/oracle.md
@@ -1,10 +1,22 @@
 # Oracle
 
+### System Authentication
+```{hint}
+If you want to use system authentication to access Oracle, username & password should not present in the connection string.
+```
 
 ### Oracle Connection
 ```py
 import connectorx as cx
 conn = 'oracle://username:password@server:port/database'        # connection token
+query = 'SELECT * FROM table'                                   # query string
+cx.read_sql(conn, query)                                        # read data from Oracle
+```
+
+### Oracle TNS Alias (DNS) Connection
+```py
+import connectorx as cx
+conn = 'oracle://username:password@alias_name?alias=true'        # connection token
 query = 'SELECT * FROM table'                                   # query string
 cx.read_sql(conn, query)                                        # read data from Oracle
 ```


### PR DESCRIPTION
The use of aliases defined in tnsnames.ora is a common connection method found in Oracle, which also enables the specification of communication protocols like TCP/TCPS  (i.e. SSL-enabled) among other configurations through a DSN connection string.

This change adds parameter handling for the connection string defined for an Oracle DB connection. Specifically, the alias boolean parameter when set to true, parses the alias defined in the host directly to the oracle::Connector::new method to initialize the connector object.

For a connection using aliases, the connection string will look as such:
`oracle://<username>:<password>@<alias>?alias=true`
compared to the direct connection string method specifying host & port:
`oracle://<username>:<password>@<host>:<port>/<database>`

This will resolve issues #202, #420 & #484 — it is a requested feature for DSN connection strings in TNS aliases to be used.