### PR TITLE
feat: Linux ARM Release CICD for `glibc 2.35`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,67 +7,67 @@ on:
       - release
 
 jobs:
-  # linux:
-  #   runs-on: ubuntu-latest
-  #   container: quay.io/pypa/manylinux_2_28_x86_64
-  #   strategy:
-  #     matrix:
-  #       python-version: [[310, "3.10"], [311, "3.11"], [312, "3.12"], [313, "3.13"]]
-  #   steps:
-  #     - uses: actions/checkout@v4
+  linux:
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_28_x86_64
+    strategy:
+      matrix:
+        python-version: [[310, "3.10"], [311, "3.11"], [312, "3.12"], [313, "3.13"]]
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Set python version
-  #       run: |
-  #         echo "/opt/python/cp${{ matrix.python-version[0] }}-cp${{ matrix.python-version[0] }}/bin" >> $GITHUB_PATH
+      - name: Set python version
+        run: |
+          echo "/opt/python/cp${{ matrix.python-version[0] }}-cp${{ matrix.python-version[0] }}/bin" >> $GITHUB_PATH
 
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         components: rustfmt
-  #         target: aarch64-unknown-linux-gnu
-  #         default: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          target: aarch64-unknown-linux-gnu
+          default: true
 
-  #     - uses: extractions/setup-just@v2
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: extractions/setup-just@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - uses: Gr1N/setup-poetry@v9
+      - uses: Gr1N/setup-poetry@v9
 
-  #     - name: Install tools
-  #       run: |
-  #         yum install -y epel-release
-  #         yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs clang-devel
+      - name: Install tools
+        run: |
+          yum install -y epel-release
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs clang-devel
 
-  #     - name: Setup project
-  #       run: |
-  #         just bootstrap-python
+      - name: Setup project
+        run: |
+          just bootstrap-python
 
-  #     - uses: PyO3/maturin-action@v1
-  #       with:
-  #         rust-toolchain: stable
-  #         command: build
-  #         args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28 --features integrated-auth-gssapi
-  #         before-script-linux: |
-  #           # If we're running on rhel centos, install needed packages.
-  #           if command -v yum &> /dev/null; then
-  #               yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
+      - uses: PyO3/maturin-action@v1
+        with:
+          rust-toolchain: stable
+          command: build
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28 --features integrated-auth-gssapi
+          before-script-linux: |
+            # If we're running on rhel centos, install needed packages.
+            if command -v yum &> /dev/null; then
+                yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
 
-  #               # If we're running on i686 we need to symlink libatomic
-  #               # in order to build openssl with -latomic flag.
-  #               if [[ ! -d "/usr/lib64" ]]; then
-  #                   ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
-  #               fi
-  #           else
-  #               # If we're running on debian-based system.
-  #               apt update -y && apt-get install -y libssl-dev openssl pkg-config
-  #           fi
-  #       env:
-  #         SQLITE3_STATIC: 1
+                # If we're running on i686 we need to symlink libatomic
+                # in order to build openssl with -latomic flag.
+                if [[ ! -d "/usr/lib64" ]]; then
+                    ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
+                fi
+            else
+                # If we're running on debian-based system.
+                apt update -y && apt-get install -y libssl-dev openssl pkg-config
+            fi
+        env:
+          SQLITE3_STATIC: 1
 
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: "ubuntu-latest-${{ matrix.python-version[1] }}"
-  #         path: connectorx-python/target/wheels/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "ubuntu-latest-${{ matrix.python-version[1] }}"
+          path: connectorx-python/target/wheels/*.whl
 
   linux-aarch:
     runs-on: ubuntu-22.04-arm
@@ -105,6 +105,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y mysql-client libpq-dev freetds-dev krb5-locales clang libkrb5-dev build-essential gcc musl-tools libsasl2-modules-gssapi-mit libgssapi-krb5-2 krb5-user
       - name: Setup Poetry
         uses: Gr1N/setup-poetry@v9
 
@@ -117,6 +121,10 @@ jobs:
       - name: Build Wheel (Native)
         run: |
           maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
+        env:
+          SQLITE3_STATIC: 1
+          KRB5_INCLUDE_DIR: /usr/include
+          KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
@@ -124,148 +132,148 @@ jobs:
           name: "linux-arm-${{ matrix.python-version }}"
           path: connectorx-python/target/wheels/*.whl
 
-  # win-and-mac:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: ["windows-latest", "macos-13"]
-  #       python-version: ["3.10", "3.11", "3.12", "3.13"]
-  #       include:
-  #         - os: "macos-13"
-  #           features: "--features integrated-auth-gssapi"
-  #   steps:
-  #     - uses: actions/checkout@v4
+  win-and-mac:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["windows-latest", "macos-13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: "macos-13"
+            features: "--features integrated-auth-gssapi"
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: ankane/setup-mysql@v1
-  #       with:
-  #         mysql-version: 8
+      - uses: ankane/setup-mysql@v1
+        with:
+          mysql-version: 8
 
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #         architecture: x64
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
 
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         components: rustfmt
-  #         default: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          default: true
 
-  #     - uses: extractions/setup-just@v2
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: extractions/setup-just@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - uses: Gr1N/setup-poetry@v9
+      - uses: Gr1N/setup-poetry@v9
 
-  #     - name: Setup project
-  #       run: |
-  #         just bootstrap-python
+      - name: Setup project
+        run: |
+          just bootstrap-python
 
-  #     - uses: PyO3/maturin-action@v1
-  #       with:
-  #         rust-toolchain: stable
-  #         maturin-version: v0.14.15
-  #         command: build
-  #         args: -m connectorx-python/Cargo.toml -i python --release ${{ matrix.features }}
-  #       env:
-  #         SQLITE3_STATIC: 1
+      - uses: PyO3/maturin-action@v1
+        with:
+          rust-toolchain: stable
+          maturin-version: v0.14.15
+          command: build
+          args: -m connectorx-python/Cargo.toml -i python --release ${{ matrix.features }}
+        env:
+          SQLITE3_STATIC: 1
 
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: "${{ matrix.os }}-${{ matrix.python-version }}"
-  #         path: connectorx-python/target/wheels/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "${{ matrix.os }}-${{ matrix.python-version }}"
+          path: connectorx-python/target/wheels/*.whl
 
-  # apple-arm:
-  #   runs-on: macos-latest
-  #   strategy:
-  #     matrix:
-  #       python-version: ["3.10", "3.11", "3.12", "3.13"]
-  #   steps:
-  #     - uses: actions/checkout@v4
+  apple-arm:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: ankane/setup-mysql@v1
-  #       with:
-  #         mysql-version: 8
+      - uses: ankane/setup-mysql@v1
+        with:
+          mysql-version: 8
 
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         components: rustfmt
-  #         target: aarch64-apple-darwin
-  #         default: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          target: aarch64-apple-darwin
+          default: true
 
-  #     - uses: extractions/setup-just@v2
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: extractions/setup-just@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - uses: Gr1N/setup-poetry@v9
+      - uses: Gr1N/setup-poetry@v9
 
-  #     - name: Setup project
-  #       run: |
-  #         just bootstrap-python
+      - name: Setup project
+        run: |
+          just bootstrap-python
 
-  #     - uses: PyO3/maturin-action@v1
-  #       with:
-  #         rust-toolchain: stable
-  #         maturin-version: v0.14.15
-  #         command: build
-  #         args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release  --features integrated-auth-gssapi
-  #       env:
-  #         SQLITE3_STATIC: 1
+      - uses: PyO3/maturin-action@v1
+        with:
+          rust-toolchain: stable
+          maturin-version: v0.14.15
+          command: build
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release  --features integrated-auth-gssapi
+        env:
+          SQLITE3_STATIC: 1
 
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: "macos-arm-${{ matrix.python-version }}"
-  #         path: connectorx-python/target/wheels/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "macos-arm-${{ matrix.python-version }}"
+          path: connectorx-python/target/wheels/*.whl
 
-  # verify:
-  #   runs-on: ${{ matrix.os }}
-  #   needs: [win-and-mac, linux]
-  #   strategy:
-  #     matrix:
-  #       python-version: ["3.10", "3.11", "3.12", "3.13"]
-  #       os: [macos-13, ubuntu-latest, windows-latest]
-  #   steps:
-  #     - uses: actions/checkout@v4
+  verify:
+    runs-on: ${{ matrix.os }}
+    needs: [win-and-mac, linux]
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: [macos-13, ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #         architecture: x64
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
 
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: "${{ matrix.os }}-${{ matrix.python-version }}"
+      - uses: actions/download-artifact@v4
+        with:
+          name: "${{ matrix.os }}-${{ matrix.python-version }}"
 
-  #     - run: |
-  #         pip install *.whl
-  #         python -c "import connectorx"
+      - run: |
+          pip install *.whl
+          python -c "import connectorx"
 
-  # verify-apple-arm:
-  #   runs-on: ${{ matrix.os }}
-  #   needs: [apple-arm]
-  #   strategy:
-  #     matrix:
-  #       python-version: ["3.10", "3.11", "3.12", "3.13"]
-  #       os: [macos-latest]
-  #   steps:
-  #     - uses: actions/checkout@v4
+  verify-apple-arm:
+    runs-on: ${{ matrix.os }}
+    needs: [apple-arm]
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: [macos-latest]
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: "macos-arm-${{ matrix.python-version }}"
+      - uses: actions/download-artifact@v4
+        with:
+          name: "macos-arm-${{ matrix.python-version }}"
 
-  #     - run: |
-  #         pip install *.whl
-  #         python -c "import connectorx"
+      - run: |
+          pip install *.whl
+          python -c "import connectorx"
 
   verify-linux-arm:
     runs-on: ubuntu-22.04-arm
@@ -302,39 +310,39 @@ jobs:
           pip install *.whl
           python -c 'import connectorx'
 
-  # upload:
-  #   runs-on: ubuntu-latest
-  #   needs: [verify, verify-apple-arm, verify-linux-arm]
-  #   steps:
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
+  upload:
+    runs-on: ubuntu-latest
+    needs: [verify, verify-apple-arm, verify-linux-arm]
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
 
-  #     - name: Setup environment
-  #       run: |
-  #         tree .
-  #         echo "/home/runner/.local/bin" >> $GITHUB_PATH
+      - name: Setup environment
+        run: |
+          tree .
+          echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
-  #     - name: Install Twine
-  #       run: |
-  #         pip install twine
-  #         pip install packaging -U
+      - name: Install Twine
+        run: |
+          pip install twine
+          pip install packaging -U
 
-  #     - name: Upload to PyPI site
-  #       if: github.ref == 'refs/heads/release'
-  #       env:
-  #         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-  #       run: |
-  #         for file in $(ls **/*)
-  #         do
-  #           twine upload --non-interactive -u __token__ -p $PYPI_TOKEN $file || continue
-  #         done
+      - name: Upload to PyPI site
+        if: github.ref == 'refs/heads/release'
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          for file in $(ls **/*)
+          do
+            twine upload --non-interactive -u __token__ -p $PYPI_TOKEN $file || continue
+          done
 
-  #     - name: Upload to PyPI test site
-  #       if: github.ref == 'refs/heads/prerelease'
-  #       env:
-  #         PYPI_TEST_TOKEN: ${{ secrets.PYPI_TEST_TOKEN }}
-  #       run: |
-  #         for file in $(ls **/*)
-  #         do
-  #           twine upload --non-interactive --repository-url https://test.pypi.org/legacy/ -u __token__ -p $PYPI_TEST_TOKEN $file --verbose || continue
-  #         done
+      - name: Upload to PyPI test site
+        if: github.ref == 'refs/heads/prerelease'
+        env:
+          PYPI_TEST_TOKEN: ${{ secrets.PYPI_TEST_TOKEN }}
+        run: |
+          for file in $(ls **/*)
+          do
+            twine upload --non-interactive --repository-url https://test.pypi.org/legacy/ -u __token__ -p $PYPI_TEST_TOKEN $file --verbose || continue
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,16 +126,6 @@ jobs:
           KRB5_INCLUDE_DIR: /usr/include
           KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu
 
-      - name: Copy J4RS Dependencies
-        run: |
-          cp -rf connectorx-python/target/aarch64-unknown-linux-gnu/release/jassets connectorx-python/connectorx/dependencies
-      - name: Rebuild Wheel (Native)
-        run: |
-          maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
-        env:
-          SQLITE3_STATIC: 1
-          KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu
-
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,53 +69,76 @@ jobs:
           name: "ubuntu-latest-${{ matrix.python-version[1] }}"
           path: connectorx-python/target/wheels/*.whl
 
-  # linux-aarch:
-  #   runs-on: ubuntu-latest
-  #   container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
-  #   strategy:
-  #     matrix:
-  #       python-version: [[38, "3.8"], [39, "3.9"], [310, "3.10"], [311, "3.11"]]
-  #   steps:
-  #     - uses: actions/checkout@v2
+  linux-aarch:
+    runs-on: ubuntu-22.04-arm
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-  #     - name: Set python version
-  #       run: |
-  #         echo "/opt/python/cp${{ matrix.python-version[0] }}-cp${{ matrix.python-version[0] }}/bin" >> $GITHUB_PATH
+      # Check architecture of the target machine
+      - name: Check Target Architecture
+        run: |
+          echo "Architecture: $(uname -m)"
+          if [[ $(uname -m) != "aarch64" ]]; then
+            echo "Error: This workflow requires ARM architecture (aarch64)."
+            exit 1
+          fi
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: 1.71.1
-  #         components: rustfmt
-  #         target: aarch64-unknown-linux-gnu
-  #         default: true
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          target: aarch64-unknown-linux-gnu
+          default: true
 
-  #     - uses: extractions/setup-just@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Just
+        uses: extractions/setup-just@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - uses: Gr1N/setup-poetry@v9
+      - name: Install Tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y mysql-client libpq-dev freetds-dev krb5-locales clang libkrb5-dev build-essential gcc musl-tools libsasl2-modules-gssapi-mit libgssapi-krb5-2 krb5-user
+      - name: Setup Poetry
+        uses: Gr1N/setup-poetry@v9
 
-  #     - name: Install tools
-  #       run: |
-  #         yum install -y epel-release
-  #         yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs clang-devel
+      - name: Setup Project
+        run: |
+          just bootstrap-python
+          python -m pip install --upgrade pip
+          pip install maturin
+      - name: Build Wheel (Native)
+        run: |
+          maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
+        env:
+          SQLITE3_STATIC: 1
+          KRB5_INCLUDE_DIR: /usr/include
+          KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu  # ✅ Ensured correct library path
 
-  #     - name: Setup project
-  #       run: |
-  #         just bootstrap-python
+      - name: Copy J4RS Dependencies
+        run: |
+          cp -rf connectorx-python/target/aarch64-unknown-linux-gnu/release/jassets connectorx-python/connectorx/dependencies
+      - name: Rebuild Wheel (Native)
+        run: |
+          maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
+        env:
+          SQLITE3_STATIC: 1
+          KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu
 
-  #     - uses: PyO3/maturin-action@v1
-  #       with:
-  #         rust-toolchain: 1.71.1
-  #         command: build
-  #         args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --release --manylinux 2_28 --features integrated-auth-gssapi
-  #       env:
-  #         SQLITE3_STATIC: 1
-
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: "aarch-${{ matrix.python-version[1] }}"
-  #         path: connectorx-python/target/wheels/*.whl
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "linux-arm-${{ matrix.python-version }}"
+          path: connectorx-python/target/wheels/*.whl
 
   win-and-mac:
     runs-on: ${{ matrix.os }}
@@ -238,7 +261,7 @@ jobs:
           pip install *.whl
           python -c "import connectorx"
 
-  verify-arm:
+  verify-apple-arm:
     runs-on: ${{ matrix.os }}
     needs: [apple-arm]
     strategy:
@@ -260,9 +283,43 @@ jobs:
           pip install *.whl
           python -c "import connectorx"
 
+  verify-linux-arm:
+    runs-on: ubuntu-22.04-arm  # Use native ARM64 runner instead of emulation
+    needs: [linux-aarch]
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # Check architecture of the target machine
+      - name: Check Target Architecture
+        run: |
+          echo "Architecture: $(uname -m)"
+          if [[ $(uname -m) != "aarch64" ]]; then
+            echo "Error: This workflow requires ARM architecture (aarch64)."
+            exit 1
+          fi
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "linux-arm-${{ matrix.python-version }}"
+
+      - name: Install and Test
+        run: |
+          python -m pip install --upgrade pip
+          pip install *.whl
+          python -c 'import connectorx'
+
   upload:
     runs-on: ubuntu-latest
-    needs: [verify, verify-arm]
+    needs: [verify, verify-apple-arm, verify-linux-arm]
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,16 +118,6 @@ jobs:
         run: |
           maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
 
-      - name: Copy J4RS Dependencies
-        run: |
-          cp -rf connectorx-python/target/aarch64-unknown-linux-gnu/release/jassets connectorx-python/connectorx/dependencies
-      - name: Rebuild Wheel (Native)
-        run: |
-          maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
-        env:
-          SQLITE3_STATIC: 1
-          KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu
-
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,16 @@ jobs:
         run: |
           maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
 
+      - name: Copy J4RS Dependencies
+        run: |
+          cp -rf connectorx-python/target/aarch64-unknown-linux-gnu/release/jassets connectorx-python/connectorx/dependencies
+      - name: Rebuild Wheel (Native)
+        run: |
+          maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
+        env:
+          SQLITE3_STATIC: 1
+          KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           path: connectorx-python/target/wheels/*.whl
 
   linux-aarch:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
@@ -86,6 +86,7 @@ jobs:
             echo "Error: This workflow requires ARM architecture (aarch64)."
             exit 1
           fi
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -116,6 +117,7 @@ jobs:
           just bootstrap-python
           python -m pip install --upgrade pip
           pip install maturin
+
       - name: Build Wheel (Native)
         run: |
           maturin build -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python${{ matrix.python-version }} --release
@@ -301,6 +303,7 @@ jobs:
             echo "Error: This workflow requires ARM architecture (aarch64)."
             exit 1
           fi
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,10 @@ jobs:
           path: connectorx-python/target/wheels/*.whl
 
   linux-aarch:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -122,7 +122,7 @@ jobs:
         env:
           SQLITE3_STATIC: 1
           KRB5_INCLUDE_DIR: /usr/include
-          KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu  # ✅ Ensured correct library path
+          KRB5_LIB_DIR: /usr/lib/aarch64-linux-gnu
 
       - name: Copy J4RS Dependencies
         run: |
@@ -284,11 +284,11 @@ jobs:
           python -c "import connectorx"
 
   verify-linux-arm:
-    runs-on: ubuntu-22.04-arm  # Use native ARM64 runner instead of emulation
+    runs-on: ubuntu-22.04-arm
     needs: [linux-aarch]
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This allows it to make full use of the CPU by becoming cache and branch predicto
 
 ## How does ConnectorX download the data?
 
-Upon receiving the query, e.g. `SELECT * FROM lineitem`, ConnectorX will first issue a `LIMIT 1` query `SELECT * FROM lineitem LIMIT 1` to get the schema of the result set.
+Upon receiving the query, e.g. `SELECT * FROM lineitem`, ConnectorX will first get the schema of the result set. Depending on the data source, this process may envolve issuing a `LIMIT 1` query `SELECT * FROM lineitem LIMIT 1`.
 
 Then, if `partition_on` is specified, ConnectorX will issue `SELECT MIN($partition_on), MAX($partition_on) FROM (SELECT * FROM lineitem)` to know the range of the partition column.
 After that, the original query is split into partitions based on the min/max information, e.g. `SELECT * FROM (SELECT * FROM lineitem) WHERE $partition_on > 0 AND $partition_on < 10000`.


### PR DESCRIPTION
This change re-introduces the Linux ARM Build process to the release workflow and seeks to address the long-standing issue of missing `connector-x` wheels for Linux ARM in #240, #386, #506, #535, #673, #724 and more recently, #773.

With the introduction of GitHub ARM-based runners earlier this year in public preview, it is now possible to build our distribution natively in an ARM-based Ubuntu 22.04 environment, which should allow compatibility with OSes using `glibc 2.35` and above.

A test run can be found in my fork here:
https://github.com/pangjunrong/connector-x/actions/runs/13912310291