### PR TITLE
refactor: Optimize DataFrame Reconstruction & Update Docs for Linux ARM64 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Check out more detailed usage and examples [here](https://sfu-db.github.io/conne
 pip install connectorx
 ```
 
+_For AArch64 or ARM64 Linux users, `connectorx==0.4.3 & above` is only available for distributions using `glibc 2.35` and above. Specifically, the re-release for this architecture was tested on Ubuntu 22.04. For older distributions, the latest version available is `connectorx==0.2.3` due to dependency limitations._
+
 Check out [here](https://sfu-db.github.io/connector-x/install.html#build-from-source-code) to see how to build python wheel from source.
 
 # Performance

--- a/connectorx-python/connectorx/__init__.py
+++ b/connectorx-python/connectorx/__init__.py
@@ -459,20 +459,16 @@ def reconstruct_pandas(df_infos: _DataframeInfos) -> pd.DataFrame:
                 pd.core.internals.make_block(block_data, placement=binfo.cids)
             )
         elif binfo.dt == 1:  # IntegerArray
-            integer_array = pd.core.arrays.IntegerArray._from_sequence(block_data[0])
-            integer_array._mask = block_data[1]
             blocks.append(
                 pd.core.internals.make_block(
-                    integer_array,
+                    pd.core.arrays.IntegerArray(block_data[0], block_data[1]),
                     placement=binfo.cids[0],
                 )
             )
         elif binfo.dt == 2:  # BooleanArray
-            bool_array = pd.core.arrays.BooleanArray._from_sequence(block_data[0])
-            bool_array._mask = block_data[1]
             blocks.append(
                 pd.core.internals.make_block(
-                    bool_array,
+                    pd.core.arrays.BooleanArray(block_data[0], block_data[1]),
                     placement=binfo.cids[0],
                 )
             )

--- a/connectorx-python/connectorx/__init__.py
+++ b/connectorx-python/connectorx/__init__.py
@@ -459,23 +459,27 @@ def reconstruct_pandas(df_infos: _DataframeInfos) -> pd.DataFrame:
                 pd.core.internals.make_block(block_data, placement=binfo.cids)
             )
         elif binfo.dt == 1:  # IntegerArray
+            integer_array = pd.core.arrays.IntegerArray._from_sequence(block_data[0])
+            integer_array._mask = block_data[1]
             blocks.append(
                 pd.core.internals.make_block(
-                    pd.core.arrays.IntegerArray(block_data[0], block_data[1]),
+                    integer_array,
                     placement=binfo.cids[0],
                 )
             )
         elif binfo.dt == 2:  # BooleanArray
+            bool_array = pd.core.arrays.BooleanArray._from_sequence(block_data[0])
+            bool_array._mask = block_data[1]
             blocks.append(
                 pd.core.internals.make_block(
-                    pd.core.arrays.BooleanArray(block_data[0], block_data[1]),
+                    bool_array,
                     placement=binfo.cids[0],
                 )
             )
         elif binfo.dt == 3:  # DatetimeArray
             blocks.append(
                 pd.core.internals.make_block(
-                    pd.core.arrays.DatetimeArray(block_data), placement=binfo.cids
+                    pd.core.arrays.DatetimeArray._from_sequence(block_data), placement=binfo.cids
                 )
             )
         else:
@@ -484,7 +488,7 @@ def reconstruct_pandas(df_infos: _DataframeInfos) -> pd.DataFrame:
     block_manager = pd.core.internals.BlockManager(
         blocks, [pd.Index(headers), pd.RangeIndex(start=0, stop=nrows, step=1)]
     )
-    df = pd.DataFrame(block_manager)
+    df = pd.DataFrame._from_mgr(block_manager, axes=[headers, range(nrows)])
     return df
 
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,6 +10,10 @@ The easiest way to install ConnectorX is using pip, with the following command:
 pip install connectorx
 ```
 
+```{note}
+For AArch64 or ARM64 Linux users, connectorx==0.4.3 and above is only available for distributions using `glibc 2.35` and above. Specifically, the re-release for this architecture was tested on Ubuntu 22.04. For older distributions, the latest version available is connectorx==0.2.3 due to dependency limitations.
+```
+
 ### Build from source code
 
 * Step 0: Install tools.

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@ pip install connectorx
 ```
 
 ```{note}
-For AArch64 or ARM64 Linux users, connectorx==0.4.3 and above is only available for distributions using `glibc 2.35` and above. Specifically, the re-release for this architecture was tested on Ubuntu 22.04. For older distributions, the latest version available is connectorx==0.2.3 due to dependency limitations.
+For AArch64 or ARM64 Linux users, `connectorx==0.4.3 & above` is only available for distributions using `glibc 2.35` and above. Specifically, the re-release for this architecture was tested on Ubuntu 22.04. For older distributions, the latest version available is `connectorx==0.2.3` due to dependency limitations.
 ```
 
 ### Build from source code


### PR DESCRIPTION
This change optimizes the reconstruction of Pandas DataFrames using the `_from_sequence` methods for ExtensionArrays, which run on bulk conversion routines using vectorized NumPy operations while avoiding the extra layers of validation in the general constructor.

It also uses the `_from_mgr` method for DataFrame construction using BlockManager, which assumes the BlockManager is already in a valid state and skips the validation and setup overhead that the regular pd.DataFrame(BlockManager) constructor performs.

This also resolves the warnings mentioned in #786.

Based on a simple generic benchmark between the typical class initialization and use of `_from_sequence`, the performance gain seems to be consistent & profound across BooleanArray, DatetimeArray & IntegerArray. However, I will need help for additional verification on this as I don't fully understand the full picture of how Pandas Internals operate at the lower level.

![BooleanArray](https://github.com/user-attachments/assets/57c34141-7bdc-44dd-89b3-0a72ebf28617)
![DatetimeArray](https://github.com/user-attachments/assets/a1a6385d-45e7-4d2c-8bd1-9de603f0b584)
![IntegerArray](https://github.com/user-attachments/assets/5895a3e1-0944-41c4-b458-d3e07afd4037)

Separately, the installation guides are updated to inform users of `connectorx==0.4.3`'s general availability for Linux ARM64 distributions running on glibc 2.35 & later and the use of `connectorx=0.2.3` for older distributions not covered by our new build process.