### PR TITLE
try an additional format to parse bq timestamps

### DIFF
--- a/connectorx/src/sources/bigquery/mod.rs
+++ b/connectorx/src/sources/bigquery/mod.rs
@@ -768,7 +768,7 @@ impl<'r, 'a> Produce<'r, NaiveDateTime> for BigQuerySourceParser {
             .as_str()
             .ok_or_else(|| anyhow!("cannot get str from json value"))?;
         NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
-            .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.F"))
+            .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f"))
             .map_err(|_| ConnectorXError::cannot_produce::<NaiveDateTime>(Some(s.into())))?
     }
 }
@@ -840,10 +840,10 @@ impl<'r, 'a> Produce<'r, Option<NaiveDateTime>> for BigQuerySourceParser {
                     .ok_or_else(|| anyhow!("cannot get str from json value"))?;
                 Some(
                     NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
-                    .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.F"))
-                    .map_err(|_| {
-                        ConnectorXError::cannot_produce::<NaiveDateTime>(Some(s.into()))
-                    })?,
+                        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f"))
+                        .map_err(|_| {
+                            ConnectorXError::cannot_produce::<NaiveDateTime>(Some(s.into()))
+                        })?,
                 )
             }
         }


### PR DESCRIPTION
I got the following error while using this library to pull data from BigQuery. Took a shot at fixing it.

```
RuntimeError: Cannot produce a chrono::naive::datetime::NaiveDateTime, context: 2025-05-07T01:03:40.377671.
```