### PR TITLE
feat(postgres): Added support for PostgreSQL `OID` type conversion (as `u32`)

### DIFF
--- a/connectorx-python/src/pandas/transports/postgres.rs
+++ b/connectorx-python/src/pandas/transports/postgres.rs
@@ -35,6 +35,7 @@ macro_rules! impl_postgres_transport {
                 { Int2[i16]                                     => I64[i64]                               | conversion auto }
                 { Int4[i32]                                     => I64[i64]                               | conversion auto }
                 { Int8[i64]                                     => I64[i64]                               | conversion auto }
+                { UInt4[u32]                                    => I64[i64]                               | conversion auto }
                 { BoolArray[Vec<Option<bool>>]                  => BoolArray[Vec<bool>]                   | conversion option }
                 { Int2Array[Vec<Option<i16>>]                   => I64Array[Vec<i64>]                     | conversion option }
                 { Int4Array[Vec<Option<i32>>]                   => I64Array[Vec<i64>]                     | conversion option }

--- a/connectorx/src/sources/postgres/mod.rs
+++ b/connectorx/src/sources/postgres/mod.rs
@@ -514,6 +514,7 @@ impl_produce!(
     i16,
     i32,
     i64,
+    u32,
     f32,
     f64,
     Decimal,
@@ -752,7 +753,7 @@ macro_rules! impl_csv_produce {
     };
 }
 
-impl_csv_produce!(i8, i16, i32, i64, f32, f64, Uuid, IpInet,);
+impl_csv_produce!(i8, i16, i32, i64, u32, f32, f64, Uuid, IpInet,);
 
 macro_rules! impl_csv_vec_produce {
     ($($t: ty,)+) => {
@@ -1239,6 +1240,7 @@ impl_produce!(
     i16,
     i32,
     i64,
+    u32,
     f32,
     f64,
     Decimal,
@@ -1494,7 +1496,7 @@ macro_rules! impl_simple_produce {
     };
 }
 
-impl_simple_produce!(i8, i16, i32, i64, f32, f64, Uuid, IpInet,);
+impl_simple_produce!(i8, i16, i32, i64, u32, f32, f64, Uuid, IpInet,);
 
 impl<'r> Produce<'r, bool> for PostgresSimpleSourceParser {
     type Error = PostgresSourceError;

--- a/connectorx/src/sources/postgres/typesystem.rs
+++ b/connectorx/src/sources/postgres/typesystem.rs
@@ -17,6 +17,7 @@ pub enum PostgresTypeSystem {
     Int2(bool),
     Int4(bool),
     Int8(bool),
+    UInt4(bool),
     Float4Array(bool),
     Float8Array(bool),
     NumericArray(bool),
@@ -54,6 +55,7 @@ impl_typesystem! {
         { Int2 => i16 }
         { Int4 => i32 }
         { Int8 => i64 }
+        { UInt4 => u32 }
         { Float4 => f32 }
         { Float8 => f64 }
         { Numeric => Decimal }
@@ -91,6 +93,7 @@ impl<'a> From<&'a Type> for PostgresTypeSystem {
             "int2" => Int2(true),
             "int4" => Int4(true),
             "int8" => Int8(true),
+            "oid" => UInt4(true),
             "float4" => Float4(true),
             "float8" => Float8(true),
             "numeric" => Numeric(true),
@@ -132,7 +135,7 @@ impl<'a> From<&'a Type> for PostgresTypeSystem {
 
 pub struct PostgresTypePairs<'a>(pub &'a Type, pub &'a PostgresTypeSystem);
 
-// Link (postgres::Type, connectorx::PostgresTypes) back to the one defiend by the postgres crate.
+// Link (postgres::Type, connectorx::PostgresTypes) back to the one defined by the postgres crate.
 impl From<PostgresTypePairs<'_>> for Type {
     fn from(ty: PostgresTypePairs) -> Type {
         use PostgresTypeSystem::*;

--- a/connectorx/src/transports/postgres_arrow.rs
+++ b/connectorx/src/transports/postgres_arrow.rs
@@ -52,6 +52,7 @@ macro_rules! impl_postgres_transport {
                 { Int2[i16]                          => Int16[i16]                             | conversion auto   }
                 { Int4[i32]                          => Int32[i32]                             | conversion auto   }
                 { Int8[i64]                          => Int64[i64]                             | conversion auto   }
+                { UInt4[u32]                         => UInt32[u32]                            | conversion auto   }
                 { Bool[bool]                         => Boolean[bool]                          | conversion auto   }
                 { Text[&'r str]                      => LargeUtf8[String]                      | conversion owned  }
                 { BpChar[&'r str]                    => LargeUtf8[String]                      | conversion none   }


### PR DESCRIPTION
Minor addition of support for the `oid` PostgreSQL identifier type, so it's a little easier to interact with system tables; `oid` is a `u32` type, and can be directly read as such.

Ref: [PostgreSQL OID type details](https://pgpedia.info/o/oid.html#:~:text=unsigned%2032%20bit%20integer).

### Example

Loading some data from the `pg_class` system table:

```python
import connectorx as cx

cx.read_sql(
    conn="postgresql://<user>:<pass>@<host>:<port>/<db>",
    query="""
        SELECT oid, relname 
        FROM pg_class
        WHERE relkind = 't'
    """,
    return_type="polars",
)
```

**Before:**
```python
# PanicException: not implemented: oid
```
**After:**
```python
# shape: (88, 2)
# ┌───────────┬────────────────────┐
# │ oid       ┆ relname            │
# │ ---       ┆ ---                │
# │ u32       ┆ str                │
# ╞═══════════╪════════════════════╡
# │ 75665     ┆ pg_toast_75661     │
# │ 75676     ┆ pg_toast_75672     │
# │ 337455076 ┆ pg_toast_337455072 │
# │ …         ┆ …                  │
# │ 3772379   ┆ pg_toast_3772376   │
# │ 3772397   ┆ pg_toast_3772393   │
# │ 4066652   ┆ pg_toast_4066648   │
# └───────────┴────────────────────┘
```