### PR TITLE
Fix 3 HIGH severity bugs: silent thread panics and channel expect panics

### DIFF
--- a/connectorx/src/arrow_batch_iter.rs
+++ b/connectorx/src/arrow_batch_iter.rs
@@ -72,7 +72,7 @@ where
         let dst_partitions = self.dst_parts.take().unwrap();
         let dorder = self.dorder;
 
-        std::thread::spawn(move || -> Result<(), TP::Error> {
+        let handle = std::thread::spawn(move || -> Result<(), TP::Error> {
             let schemas: Vec<_> = src_schema
                 .iter()
                 .zip_eq(&dst_schema)
@@ -133,6 +133,10 @@ where
 
             Ok(())
         });
+        // Propagate thread panic if the spawned thread crashed
+        if let Err(payload) = handle.join() {
+            std::panic::panic_any(payload);
+        }
     }
 }
 

--- a/connectorx/src/fed_dispatcher.rs
+++ b/connectorx/src/fed_dispatcher.rs
@@ -38,12 +38,12 @@ pub fn run(
         |s, (i, p)| -> Result<(), ConnectorXOutError> {
             match p.db_name.as_str() {
                 "LOCAL" => {
-                    s.send((p.sql, None)).expect("send error local");
+                    s.send((p.sql, None)).map_err(|_| ConnectorXOutError::Anyhow(anyhow::anyhow!("local send channel disconnected")))?;
                 }
                 _ => {
                     debug!("start query {}: {}", i, p.sql);
                     let mut queries = vec![];
-                    p.sql.split(';').for_each(|ss| {
+                    p.sql.split(';').filter(|ss| !ss.trim().is_empty()).for_each(|ss| {
                         queries.push(CXQuery::naked(ss));
                     });
                     let source_conn = &db_conn_map[p.db_name.as_str()]
@@ -56,7 +56,7 @@ pub fn run(
 
                     let provider = MemTable::try_new(rbs[0].schema(), vec![rbs])?;
                     s.send((p.db_alias, Some(Arc::new(provider))))
-                        .expect(&format!("send error {}", i));
+                        .map_err(|_| ConnectorXOutError::Anyhow(anyhow::anyhow!("result send channel disconnected for query {}", i)))?;
                     debug!("query {} finished", i);
                 }
             }


### PR DESCRIPTION
## Summary of Changes

This PR fixes **3 HIGH severity bugs** found via automated Claude Code audit:

### 1. [HIGH] connectorx/src/arrow_batch_iter.rs — Silent thread panic swallowing
**File:** arrow_batch_iter.rs, run() method
**Bug:** std::thread::spawn() result (JoinHandle) was discarded. If the spawned thread panicked, the error was silently lost with no indication to the caller.
**Fix:** Store the JoinHandle and call .join() to propagate any thread panic instead of dropping the handle.

### 2. [HIGH] connectorx/src/fed_dispatcher.rs — Channel send .expect() panic (LOCAL path)
**File:** fed_dispatcher.rs, run() function
**Bug:** s.send((p.sql, None)).expect() — if the receiver is dropped, this will panic. In a parallel iterator context this is particularly dangerous.
**Fix:** Replace .expect() with .map_err() for graceful error propagation.

### 3. [HIGH] connectorx/src/fed_dispatcher.rs — Channel send .expect() panic (result path)
**File:** fed_dispatcher.rs, run() function
**Bug:** Same .expect() issue on the result channel send for remote queries.
**Fix:** Same graceful error handling instead of panicking.

### 4. [MEDIUM] connectorx/src/fed_dispatcher.rs — Empty string SQL split
**Bug:** p.sql.split(';').for_each() pushes empty CXQuery entries for trailing semicolons, potentially causing invalid query errors downstream.
**Fix:** Filter empty strings: p.sql.split(';').filter(|ss| !ss.trim().is_empty()).for_each(...)

---
*Found automatically via Claude Code security/correctness audit for HIGH+ severity bugs in the connector-x Rust codebase.*