### PR TITLE
Fix panic when SQLite connection URL is shorter than 9 characters

### DIFF
--- a/connectorx-python/src/pandas/mod.rs
+++ b/connectorx-python/src/pandas/mod.rs
@@ -28,6 +28,7 @@ use connectorx::{
     },
     sql::CXQuery,
 };
+use anyhow::anyhow;
 use fehler::throws;
 use log::debug;
 use postgres::NoTls;
@@ -164,7 +165,13 @@ pub fn write_pandas<'a, 'py: 'a>(
         }
         SourceType::SQLite => {
             // remove the first "sqlite://" manually since url.path is not correct for windows
-            let path = &source_conn.conn.as_str()[9..];
+            let conn_str = source_conn.conn.as_str();
+            let path = conn_str.get(9..).ok_or_else(|| {
+                ConnectorXPythonError::from(anyhow::anyhow!(
+                    "invalid sqlite connection string: {}",
+                    conn_str
+                ))
+            })?;
             let source = SQLiteSource::new(path, queries.len())?;
             let dispatcher = PandasDispatcher::<_, SqlitePandasTransport>::new(
                 source,


### PR DESCRIPTION
## Summary
Fixes a panic (index out of bounds) in `connectorx-python/src/pandas/mod.rs` when processing SQLite connection URLs shorter than 9 characters.

## Bug
In `write_pandas()`, the SQLite path is extracted using:
```rust
let path = &source_conn.conn.as_str()[9..];
```
This panics if `conn.as_str()` has fewer than 9 characters, e.g., a malformed URL like `"sqlite:"` (8 chars).

## Fix
Replaced the unsafe byte slice `[9..]` with the safe `.get(9..)` method, which returns `None` instead of panicking. The `None` case is handled by returning a proper `ConnectorXPythonError` with a descriptive message.

## Change
```rust
let conn_str = source_conn.conn.as_str();
let path = conn_str.get(9..).ok_or_else(|| {
    ConnectorXError::from(anyhow::anyhow!(
        "invalid sqlite connection string: {}",
        conn_str
    ))
})?;
```

