### PR TITLE
Fix MySQL TINYINT incorrectly mapped to Boolean in Arrow transport

### DIFF
--- a/connectorx/src/transports/mysql_arrow.rs
+++ b/connectorx/src/transports/mysql_arrow.rs
@@ -41,7 +41,7 @@ impl_transport!(
     mappings = {
         { Float[f32]                 => Float64[f64]            | conversion auto }
         { Double[f64]                => Float64[f64]            | conversion auto }
-        { Tiny[i8]                   => Boolean[bool]           | conversion option }
+        { Tiny[i8]                   => Int16[i16]              | conversion auto }
         { Short[i16]                 => Int64[i64]              | conversion auto }
         { Int24[i32]                 => Int64[i64]              | conversion none }
         { Long[i32]                  => Int64[i64]              | conversion auto }
@@ -77,7 +77,7 @@ impl_transport!(
     mappings = {
         { Float[f32]                 => Float64[f64]            | conversion auto }
         { Double[f64]                => Float64[f64]            | conversion auto }
-        { Tiny[i8]                   => Boolean[bool]           | conversion option }
+        { Tiny[i8]                   => Int16[i16]              | conversion auto }
         { Short[i16]                 => Int64[i64]              | conversion auto }
         { Int24[i32]                 => Int64[i64]              | conversion none }
         { Long[i32]                  => Int64[i64]              | conversion auto }
@@ -127,11 +127,5 @@ impl<P> TypeConversion<Decimal, f64> for MySQLArrowTransport<P> {
 impl<P> TypeConversion<Value, String> for MySQLArrowTransport<P> {
     fn convert(val: Value) -> String {
         to_string(&val).unwrap()
-    }
-}
-
-impl<P> TypeConversion<i8, bool> for MySQLArrowTransport<P> {
-    fn convert(val: i8) -> bool {
-        val != 0
     }
 }

--- a/connectorx/src/transports/mysql_arrowstream.rs
+++ b/connectorx/src/transports/mysql_arrowstream.rs
@@ -41,7 +41,7 @@ impl_transport!(
     mappings = {
         { Float[f32]                 => Float64[f64]            | conversion auto }
         { Double[f64]                => Float64[f64]            | conversion auto }
-        { Tiny[i8]                   => Boolean[bool]           | conversion option }
+        { Tiny[i8]                   => Int16[i16]              | conversion auto }
         { Short[i16]                 => Int64[i64]              | conversion auto }
         { Int24[i32]                 => Int64[i64]              | conversion none }
         { Long[i32]                  => Int64[i64]              | conversion auto }
@@ -77,7 +77,7 @@ impl_transport!(
     mappings = {
         { Float[f32]                 => Float64[f64]            | conversion auto }
         { Double[f64]                => Float64[f64]            | conversion auto }
-        { Tiny[i8]                   => Boolean[bool]           | conversion option }
+        { Tiny[i8]                   => Int16[i16]              | conversion auto }
         { Short[i16]                 => Int64[i64]              | conversion auto }
         { Int24[i32]                 => Int64[i64]              | conversion none }
         { Long[i32]                  => Int64[i64]              | conversion auto }
@@ -115,12 +115,6 @@ impl<P> TypeConversion<Decimal, f64> for MySQLArrowTransport<P> {
 impl<P> TypeConversion<Value, String> for MySQLArrowTransport<P> {
     fn convert(val: Value) -> String {
         to_string(&val).unwrap()
-    }
-}
-
-impl<P> TypeConversion<i8, bool> for MySQLArrowTransport<P> {
-    fn convert(val: i8) -> bool {
-        val != 0
     }
 }
 

--- a/connectorx/tests/test_mysql.rs
+++ b/connectorx/tests/test_mysql.rs
@@ -3,7 +3,7 @@
 mod test_db;
 
 use arrow::{
-    array::{Float64Array, Int64Array, StringArray},
+    array::{Float64Array, Int16Array, Int64Array, StringArray},
     record_batch::RecordBatch,
 };
 use connectorx::{
@@ -301,4 +301,66 @@ fn test_mysql_binary_flag_for_varchar_type() {
         MySQLTypeSystem::VarChar(true) => {} // OK
         _ => panic!("VARCHAR should map to VarChar, got {:?}", result),
     }
+}
+
+#[test]
+fn test_mysql_tinyint_not_bool() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let dburl = test_db::mysql_url();
+
+    let queries = [CXQuery::naked(
+        "SELECT test_tiny FROM test_types WHERE test_tiny IS NOT NULL ORDER BY test_tiny",
+    )];
+
+    let builder = MySQLSource::<BinaryProtocol>::new(&dburl, 1).unwrap();
+    let mut destination = ArrowDestination::new();
+    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<BinaryProtocol>>::new(
+        builder,
+        &mut destination,
+        &queries,
+        None,
+    );
+    dispatcher.run().unwrap();
+
+    let result = destination.arrow().unwrap();
+    assert!(result.len() == 1);
+
+    // TINYINT values must be preserved as Int16, not collapsed to Boolean.
+    // Before this fix, -128 and 127 would both become `true`.
+    assert!(result[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int16Array>()
+        .unwrap()
+        .eq(&Int16Array::from(vec![-128i16, 127])));
+}
+
+#[test]
+fn test_mysql_tinyint_not_bool_text() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let dburl = test_db::mysql_url();
+
+    let queries = [CXQuery::naked(
+        "SELECT test_tiny FROM test_types WHERE test_tiny IS NOT NULL ORDER BY test_tiny",
+    )];
+
+    let builder = MySQLSource::<TextProtocol>::new(&dburl, 1).unwrap();
+    let mut destination = ArrowDestination::new();
+    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<TextProtocol>>::new(
+        builder,
+        &mut destination,
+        &queries,
+        None,
+    );
+    dispatcher.run().unwrap();
+
+    let result = destination.arrow().unwrap();
+    assert!(result.len() == 1);
+
+    assert!(result[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int16Array>()
+        .unwrap()
+        .eq(&Int16Array::from(vec![-128i16, 127])));
 }


### PR DESCRIPTION
## Summary

Fix a data corruption bug where MySQL `TINYINT` values outside {0, 1} are silently converted to boolean `true`, losing the original value.

Fixes #779
Fixes #494

## Problem

The MySQL → Arrow transport maps `Tiny[i8]` to `Boolean[bool]` with a conversion function `val != 0`. This means any non-zero TINYINT value (e.g. -128, 2, 3, 127) becomes `true`, silently destroying data.

MySQL `TINYINT` is commonly used for small integer values such as level codes (0-3) or status flags, not just booleans. This mapping was introduced in commit 2570c4c and was not present in v0.3.0.

## Fix

- Changed `Tiny[i8]` mapping from `Boolean[bool]` to `Int16[i16]` for both `BinaryProtocol` and `TextProtocol` in both Arrow and ArrowStream transports
- Removed the manual `TypeConversion<i8, bool>` implementation from both transports

`Int16` is used because `ArrowTypeSystem` does not currently include an `Int8` variant (PostgreSQL has no 8-bit integer type, so #743 did not add one). `Int16` can represent the full signed TINYINT range (-128 to 127) without loss.

## Consistency

The MySQL → **pandas** transport in this same codebase already maps `Tiny[i8]` to `I64[i64]`, and the existing test `test_mysql_types_binary` in the Python test suite verifies that TINYINT values like -128 and 127 round-trip correctly as integers. This PR brings the Arrow and ArrowStream transports in line with that established behavior.

## Tests

Added regression tests (`test_mysql_tinyint_not_bool` and `test_mysql_tinyint_not_bool_text`) that verify TINYINT values -128 and 127 are preserved as `Int16` through both protocols.

All 10 MySQL Arrow tests pass locally.