### PR TITLE
Fix MySQL BIGINT UNSIGNED mapped to Float64 causing precision loss in Arrow transport

### DIFF
--- a/connectorx/src/transports/mysql_arrow.rs
+++ b/connectorx/src/transports/mysql_arrow.rs
@@ -50,7 +50,7 @@ impl_transport!(
         { UShort[u16]                => Int64[i64]              | conversion auto }
         { ULong[u32]                 => Int64[i64]              | conversion auto }
         { UInt24[u32]                => Int64[i64]              | conversion none }
-        { ULongLong[u64]             => Float64[f64]            | conversion auto }
+        { ULongLong[u64]             => UInt64[u64]             | conversion auto }
         { Date[NaiveDate]            => Date32[NaiveDate]       | conversion auto }
         { Time[NaiveTime]            => Time64Micro[NaiveTimeWrapperMicro]       | conversion option }
         { Datetime[NaiveDateTime]    => Date64Micro[NaiveDateTimeWrapperMicro]   | conversion option }
@@ -86,7 +86,7 @@ impl_transport!(
         { UShort[u16]                => Int64[i64]              | conversion auto }
         { ULong[u32]                 => Int64[i64]              | conversion auto }
         { UInt24[u32]                => Int64[i64]              | conversion none }
-        { ULongLong[u64]             => Float64[f64]            | conversion auto }
+        { ULongLong[u64]             => UInt64[u64]             | conversion auto }
         { Date[NaiveDate]            => Date32[NaiveDate]       | conversion auto }
         { Time[NaiveTime]            => Time64Micro[NaiveTimeWrapperMicro]       | conversion option }
         { Datetime[NaiveDateTime]    => Date64Micro[NaiveDateTimeWrapperMicro]   | conversion option }

--- a/connectorx/src/transports/mysql_arrowstream.rs
+++ b/connectorx/src/transports/mysql_arrowstream.rs
@@ -50,7 +50,7 @@ impl_transport!(
         { UShort[u16]                => Int64[i64]              | conversion auto }
         { ULong[u32]                 => Int64[i64]              | conversion auto }
         { UInt24[u32]                => Int64[i64]              | conversion none }
-        { ULongLong[u64]             => Float64[f64]            | conversion auto }
+        { ULongLong[u64]             => UInt64[u64]             | conversion auto }
         { Date[NaiveDate]            => Date32[NaiveDate]       | conversion auto }
         { Time[NaiveTime]            => Time64Micro[NaiveTimeWrapperMicro]       | conversion option }
         { Datetime[NaiveDateTime]    => Date64Micro[NaiveDateTimeWrapperMicro]   | conversion option }
@@ -86,7 +86,7 @@ impl_transport!(
         { UShort[u16]                => Int64[i64]              | conversion auto }
         { ULong[u32]                 => Int64[i64]              | conversion auto }
         { UInt24[u32]                => Int64[i64]              | conversion none }
-        { ULongLong[u64]             => Float64[f64]            | conversion auto }
+        { ULongLong[u64]             => UInt64[u64]             | conversion auto }
         { Date[NaiveDate]            => Date32[NaiveDate]       | conversion auto }
         { Time[NaiveTime]            => Time64Micro[NaiveTimeWrapperMicro]       | conversion option }
         { Datetime[NaiveDateTime]    => Date64Micro[NaiveDateTimeWrapperMicro]   | conversion option }

--- a/connectorx/tests/test_mysql.rs
+++ b/connectorx/tests/test_mysql.rs
@@ -3,7 +3,7 @@
 mod test_db;
 
 use arrow::{
-    array::{Float64Array, Int16Array, Int64Array, StringArray},
+    array::{Float64Array, Int16Array, Int64Array, StringArray, UInt64Array},
     record_batch::RecordBatch,
 };
 use connectorx::{
@@ -363,4 +363,68 @@ fn test_mysql_tinyint_not_bool_text() {
         .downcast_ref::<Int16Array>()
         .unwrap()
         .eq(&Int16Array::from(vec![-128i16, 127])));
+}
+
+#[test]
+fn test_mysql_bigint_unsigned_not_float() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let dburl = test_db::mysql_url();
+
+    let queries = [CXQuery::naked(
+        "SELECT test_longlong_unsigned FROM test_types WHERE test_longlong_unsigned IS NOT NULL ORDER BY test_longlong_unsigned",
+    )];
+
+    let builder = MySQLSource::<BinaryProtocol>::new(&dburl, 1).unwrap();
+    let mut destination = ArrowDestination::new();
+    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<BinaryProtocol>>::new(
+        builder,
+        &mut destination,
+        &queries,
+        None,
+    );
+    dispatcher.run().unwrap();
+
+    let result = destination.arrow().unwrap();
+    assert!(result.len() == 1);
+
+    // BIGINT UNSIGNED must be UInt64, not Float64.
+    // Float64 loses precision for values exceeding 2^53 (see #890).
+    let col = result[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap();
+
+    assert_eq!(col.value(0), 0u64);
+}
+
+#[test]
+fn test_mysql_bigint_unsigned_not_float_text() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let dburl = test_db::mysql_url();
+
+    let queries = [CXQuery::naked(
+        "SELECT test_longlong_unsigned FROM test_types WHERE test_longlong_unsigned IS NOT NULL ORDER BY test_longlong_unsigned",
+    )];
+
+    let builder = MySQLSource::<TextProtocol>::new(&dburl, 1).unwrap();
+    let mut destination = ArrowDestination::new();
+    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<TextProtocol>>::new(
+        builder,
+        &mut destination,
+        &queries,
+        None,
+    );
+    dispatcher.run().unwrap();
+
+    let result = destination.arrow().unwrap();
+    assert!(result.len() == 1);
+
+    let col = result[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap();
+
+    assert_eq!(col.value(0), 0u64);
 }


### PR DESCRIPTION
## Summary

Fix incorrect type mapping where MySQL `BIGINT UNSIGNED` is converted to Float64 instead of UInt64 in the Arrow transport. This causes precision loss for values exceeding 2^53.

Fixes #664

## Problem

The MySQL → Arrow transport maps `ULongLong[u64]` to `Float64[f64]`. IEEE 754 Float64 can only represent integers exactly up to 2^53 (9007199254740992). Values above this threshold silently lose precision.

As #664 points out, `LongLong[i64]` is already correctly mapped to `Int64[i64]`, while `ULongLong[u64]` was the only unsigned integer type mapped to Float64.

## Fix

Changed `ULongLong[u64]` mapping from `Float64[f64]` to `UInt64[u64]` for both `BinaryProtocol` and `TextProtocol` in both Arrow and ArrowStream transports.

`ArrowTypeSystem` already includes a `UInt64` variant with full support in `arrow_assoc.rs`, so no destination-layer changes are needed.

## Scope

This PR addresses MySQL Arrow and ArrowStream transports only.

The pandas transport also maps `ULongLong` to `F64`, causing the same precision loss (as reported in #890). Fixing the pandas side would require adding a `UInt64` variant to `PandasTypeSystem`, which is a larger change left for a separate PR.

## Consistency

I checked all Arrow transports in this codebase. MySQL was the only source where unsigned 64-bit integers were mapped to Float64. The ClickHouse Arrow transport already correctly maps `UInt64[u64] → UInt64[u64]`. No other source database (PostgreSQL, MSSQL, Oracle, SQLite, BigQuery, Trino) has unsigned 64-bit integer types.

Other MySQL unsigned integer types are also mapped to integer Arrow types (`UTiny → Int64`, `UShort → Int64`, `ULong → Int64`), making `ULongLong` the only unsigned type that was converted to Float64.

## Impact

This fix also applies to databases using the MySQL wire protocol, such as SingleStore, when accessed via Arrow or ArrowStream return types.

## Tests

Added regression tests (`test_mysql_bigint_unsigned_not_float` and `test_mysql_bigint_unsigned_not_float_text`) that verify BIGINT UNSIGNED values are returned as `UInt64` through both protocols.