### PR TITLE
fix(arrow_stream): propagate errors instead of panicking on connection setup

### DIFF
--- a/connectorx-cpp/src/lib.rs
+++ b/connectorx-cpp/src/lib.rs
@@ -281,7 +281,8 @@ pub unsafe extern "C" fn connectorx_scan_iter(
     }
 
     let arrow_iter: Box<dyn RecordBatchIterator> =
-        new_record_batch_iter(&source_conn, None, query_vec.as_slice(), batch_size, None);
+        new_record_batch_iter(&source_conn, None, query_vec.as_slice(), batch_size, None)
+            .unwrap();
 
     Box::into_raw(Box::new(arrow_iter))
 }

--- a/connectorx-python/connectorx/tests/test_postgres.py
+++ b/connectorx-python/connectorx/tests/test_postgres.py
@@ -888,6 +888,33 @@ def test_postgres_tls_disable(postgres_url_tls: str) -> None:
     not os.environ.get("POSTGRES_URL_TLS"),
     reason="Do not test Postgres TLS unless `POSTGRES_URL_TLS` is set",
 )
+def test_postgres_tls_arrow_stream(postgres_url_tls: str) -> None:
+    query = "SELECT * FROM test_table"
+    reader = read_sql(
+        f"{postgres_url_tls}?sslmode=require",
+        query,
+        return_type="arrow_stream",
+    )
+    batches = list(reader)
+    assert len(batches) > 0
+    assert batches[0].num_columns > 0
+
+
+@pytest.mark.skipif(
+    not os.environ.get("POSTGRES_URL_TLS"),
+    reason="Do not test Postgres TLS unless `POSTGRES_URL_TLS` is set",
+)
+def test_postgres_tls_arrow_stream_bad_host_raises(postgres_url_tls: str) -> None:
+    bad_url = "postgresql://user:pass@127.0.0.1:1?sslmode=require"
+    with pytest.raises(RuntimeError):
+        reader = read_sql(bad_url, "SELECT 1", return_type="arrow_stream")
+        list(reader)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("POSTGRES_URL_TLS"),
+    reason="Do not test Postgres TLS unless `POSTGRES_URL_TLS` is set",
+)
 @pytest.mark.xfail
 def test_postgres_tls_fail(postgres_url_tls: str) -> None:
     query = "SELECT * FROM test_table"

--- a/connectorx-python/src/arrow.rs
+++ b/connectorx-python/src/arrow.rs
@@ -112,7 +112,7 @@ pub fn get_arrow_rb_iter<'py>(
         queries,
         batch_size,
         pre_execution_queries,
-    );
+    )?;
 
     arrow_iter.prepare();
     let py_rb_iter = PyRecordBatchIterator(unsafe {

--- a/connectorx/src/errors.rs
+++ b/connectorx/src/errors.rs
@@ -98,29 +98,61 @@ pub enum ConnectorXOutError {
     #[error(transparent)]
     PostgresArrowTransportError(#[from] crate::transports::PostgresArrowTransportError),
 
+    #[cfg(all(feature = "src_postgres", feature = "dst_arrow"))]
+    #[error(transparent)]
+    PostgresArrowStreamTransportError(
+        #[from] crate::transports::PostgresArrowStreamTransportError,
+    ),
+
     #[cfg(all(feature = "src_mysql", feature = "dst_arrow"))]
     #[error(transparent)]
     MySQLArrowTransportError(#[from] crate::transports::MySQLArrowTransportError),
+
+    #[cfg(all(feature = "src_mysql", feature = "dst_arrow"))]
+    #[error(transparent)]
+    MySQLArrowStreamTransportError(#[from] crate::transports::MySQLArrowStreamTransportError),
 
     #[cfg(all(feature = "src_sqlite", feature = "dst_arrow"))]
     #[error(transparent)]
     SQLiteArrowTransportError(#[from] crate::transports::SQLiteArrowTransportError),
 
+    #[cfg(all(feature = "src_sqlite", feature = "dst_arrow"))]
+    #[error(transparent)]
+    SQLiteArrowStreamTransportError(#[from] crate::transports::SQLiteArrowStreamTransportError),
+
     #[cfg(all(feature = "src_mssql", feature = "dst_arrow"))]
     #[error(transparent)]
     MsSQLArrowTransportError(#[from] crate::transports::MsSQLArrowTransportError),
+
+    #[cfg(all(feature = "src_mssql", feature = "dst_arrow"))]
+    #[error(transparent)]
+    MsSQLArrowStreamTransportError(#[from] crate::transports::MsSQLArrowStreamTransportError),
 
     #[cfg(all(feature = "src_oracle", feature = "dst_arrow"))]
     #[error(transparent)]
     OracleArrowTransportError(#[from] crate::transports::OracleArrowTransportError),
 
+    #[cfg(all(feature = "src_oracle", feature = "dst_arrow"))]
+    #[error(transparent)]
+    OracleArrowStreamTransportError(#[from] crate::transports::OracleArrowStreamTransportError),
+
     #[cfg(all(feature = "src_bigquery", feature = "dst_arrow"))]
     #[error(transparent)]
     BigqueryArrowTransportError(#[from] crate::transports::BigQueryArrowTransportError),
 
+    #[cfg(all(feature = "src_bigquery", feature = "dst_arrow"))]
+    #[error(transparent)]
+    BigqueryArrowStreamTransportError(
+        #[from] crate::transports::BigQueryArrowStreamTransportError,
+    ),
+
     #[cfg(all(feature = "src_trino", feature = "dst_arrow"))]
     #[error(transparent)]
     TrinoArrowTransportError(#[from] crate::transports::TrinoArrowTransportError),
+
+    #[cfg(all(feature = "src_trino", feature = "dst_arrow"))]
+    #[error(transparent)]
+    TrinoArrowStreamTransportError(#[from] crate::transports::TrinoArrowStreamTransportError),
 
     #[cfg(feature = "src_clickhouse")]
     #[error(transparent)]
@@ -129,6 +161,12 @@ pub enum ConnectorXOutError {
     #[cfg(all(feature = "src_clickhouse", feature = "dst_arrow"))]
     #[error(transparent)]
     ClickHouseArrowTransportError(#[from] crate::transports::ClickHouseArrowTransportError),
+
+    #[cfg(all(feature = "src_clickhouse", feature = "dst_arrow"))]
+    #[error(transparent)]
+    ClickHouseArrowStreamTransportError(
+        #[from] crate::transports::ClickHouseArrowStreamTransportError,
+    ),
 
     /// Any other errors that are too trivial to be put here explicitly.
     #[error(transparent)]

--- a/connectorx/src/get_arrow.rs
+++ b/connectorx/src/get_arrow.rs
@@ -271,6 +271,7 @@ pub fn get_arrow(
 }
 
 #[allow(unreachable_code, unreachable_patterns, unused_variables, unused_mut)]
+#[throws(ConnectorXOutError)]
 pub fn new_record_batch_iter(
     source_conn: &SourceConn,
     origin_query: Option<String>,
@@ -285,15 +286,14 @@ pub fn new_record_batch_iter(
     match source_conn.ty {
         #[cfg(feature = "src_postgres")]
         SourceType::Postgres => {
-            let (config, tls) = rewrite_tls_args(&source_conn.conn).unwrap();
+            let (config, tls) = rewrite_tls_args(&source_conn.conn)?;
             match (protocol, tls) {
                 ("csv", Some(tls_conn)) => {
                     let mut source = PostgresSource::<CSVProtocol, MakeTlsConnector>::new(
                         config,
                         tls_conn,
                         queries.len(),
-                    )
-                    .unwrap();
+                    )?;
 
                     source.set_pre_execution_queries(pre_execution_queries);
 
@@ -301,14 +301,13 @@ pub fn new_record_batch_iter(
                         ArrowBatchIter::<
                             _,
                             PostgresArrowStreamTransport<CSVProtocol, MakeTlsConnector>,
-                        >::new(source, destination, origin_query, queries)
-                        .unwrap();
-                    return Box::new(batch_iter);
+                        >::new(source, destination, origin_query, queries)?;
+                    let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+                    return iter;
                 }
                 ("csv", None) => {
                     let mut source =
-                        PostgresSource::<CSVProtocol, NoTls>::new(config, NoTls, queries.len())
-                            .unwrap();
+                        PostgresSource::<CSVProtocol, NoTls>::new(config, NoTls, queries.len())?;
 
                     source.set_pre_execution_queries(pre_execution_queries);
 
@@ -317,17 +316,16 @@ pub fn new_record_batch_iter(
                         PostgresArrowStreamTransport<CSVProtocol, NoTls>,
                     >::new(
                         source, destination, origin_query, queries
-                    )
-                    .unwrap();
-                    return Box::new(batch_iter);
+                    )?;
+                    let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+                    return iter;
                 }
                 ("binary", Some(tls_conn)) => {
                     let mut source = PostgresSource::<PgBinaryProtocol, MakeTlsConnector>::new(
                         config,
                         tls_conn,
                         queries.len(),
-                    )
-                    .unwrap();
+                    )?;
 
                     source.set_pre_execution_queries(pre_execution_queries);
 
@@ -335,17 +333,16 @@ pub fn new_record_batch_iter(
                         ArrowBatchIter::<
                             _,
                             PostgresArrowStreamTransport<PgBinaryProtocol, MakeTlsConnector>,
-                        >::new(source, destination, origin_query, queries)
-                        .unwrap();
-                    return Box::new(batch_iter);
+                        >::new(source, destination, origin_query, queries)?;
+                    let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+                    return iter;
                 }
                 ("binary", None) => {
                     let mut source = PostgresSource::<PgBinaryProtocol, NoTls>::new(
                         config,
                         NoTls,
                         queries.len(),
-                    )
-                    .unwrap();
+                    )?;
 
                     source.set_pre_execution_queries(pre_execution_queries);
 
@@ -354,17 +351,16 @@ pub fn new_record_batch_iter(
                         PostgresArrowStreamTransport<PgBinaryProtocol, NoTls>,
                     >::new(
                         source, destination, origin_query, queries
-                    )
-                    .unwrap();
-                    return Box::new(batch_iter);
+                    )?;
+                    let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+                    return iter;
                 }
                 ("cursor", Some(tls_conn)) => {
                     let mut source = PostgresSource::<CursorProtocol, MakeTlsConnector>::new(
                         config,
                         tls_conn,
                         queries.len(),
-                    )
-                    .unwrap();
+                    )?;
 
                     source.set_pre_execution_queries(pre_execution_queries);
 
@@ -372,14 +368,13 @@ pub fn new_record_batch_iter(
                         ArrowBatchIter::<
                             _,
                             PostgresArrowStreamTransport<CursorProtocol, MakeTlsConnector>,
-                        >::new(source, destination, origin_query, queries)
-                        .unwrap();
-                    return Box::new(batch_iter);
+                        >::new(source, destination, origin_query, queries)?;
+                    let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+                    return iter;
                 }
                 ("cursor", None) => {
                     let mut source =
-                        PostgresSource::<CursorProtocol, NoTls>::new(config, NoTls, queries.len())
-                            .unwrap();
+                        PostgresSource::<CursorProtocol, NoTls>::new(config, NoTls, queries.len())?;
 
                     source.set_pre_execution_queries(pre_execution_queries);
 
@@ -388,9 +383,9 @@ pub fn new_record_batch_iter(
                         PostgresArrowStreamTransport<CursorProtocol, NoTls>,
                     >::new(
                         source, destination, origin_query, queries
-                    )
-                    .unwrap();
-                    return Box::new(batch_iter);
+                    )?;
+                    let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+                    return iter;
                 }
                 _ => unimplemented!("{} protocol not supported", protocol),
             }
@@ -399,8 +394,7 @@ pub fn new_record_batch_iter(
         SourceType::MySQL => match protocol {
             "binary" => {
                 let mut source =
-                    MySQLSource::<MySQLBinaryProtocol>::new(&source_conn.conn[..], queries.len())
-                        .unwrap();
+                    MySQLSource::<MySQLBinaryProtocol>::new(&source_conn.conn[..], queries.len())?;
 
                 source.set_pre_execution_queries(pre_execution_queries);
 
@@ -410,13 +404,13 @@ pub fn new_record_batch_iter(
                         destination,
                         origin_query,
                         queries,
-                    )
-                    .unwrap();
-                return Box::new(batch_iter);
+                    )?;
+                let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+                return iter;
             }
             "text" => {
                 let mut source =
-                    MySQLSource::<TextProtocol>::new(&source_conn.conn[..], queries.len()).unwrap();
+                    MySQLSource::<TextProtocol>::new(&source_conn.conn[..], queries.len())?;
 
                 source.set_pre_execution_queries(pre_execution_queries);
 
@@ -425,9 +419,9 @@ pub fn new_record_batch_iter(
                     destination,
                     origin_query,
                     queries,
-                )
-                .unwrap();
-                return Box::new(batch_iter);
+                )?;
+                let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+                return iter;
             }
             _ => unimplemented!("{} protocol not supported", protocol),
         },
@@ -435,68 +429,70 @@ pub fn new_record_batch_iter(
         SourceType::SQLite => {
             // remove the first "sqlite://" manually since url.path is not correct for windows
             let path = &source_conn.conn.as_str()[9..];
-            let source = SQLiteSource::new(path, queries.len()).unwrap();
+            let source = SQLiteSource::new(path, queries.len())?;
             let batch_iter = ArrowBatchIter::<_, SQLiteArrowStreamTransport>::new(
                 source,
                 destination,
                 origin_query,
                 queries,
-            )
-            .unwrap();
-            return Box::new(batch_iter);
+            )?;
+            let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+            return iter;
         }
         #[cfg(feature = "src_mssql")]
         SourceType::MsSQL => {
             let rt = Arc::new(tokio::runtime::Runtime::new().expect("Failed to create runtime"));
-            let source = MsSQLSource::new(rt, &source_conn.conn[..], queries.len()).unwrap();
+            let source = MsSQLSource::new(rt, &source_conn.conn[..], queries.len())?;
             let batch_iter = ArrowBatchIter::<_, MsSQLArrowStreamTransport>::new(
                 source,
                 destination,
                 origin_query,
                 queries,
-            )
-            .unwrap();
-            return Box::new(batch_iter);
+            )?;
+            let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+            return iter;
         }
         #[cfg(feature = "src_oracle")]
         SourceType::Oracle => {
-            let source = OracleSource::new(&source_conn.conn[..], queries.len()).unwrap();
+            let source = OracleSource::new(&source_conn.conn[..], queries.len())?;
             let batch_iter = ArrowBatchIter::<_, OracleArrowStreamTransport>::new(
                 source,
                 destination,
                 origin_query,
                 queries,
-            )
-            .unwrap();
-            return Box::new(batch_iter);
+            )?;
+            let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+            return iter;
         }
         #[cfg(feature = "src_bigquery")]
         SourceType::BigQuery => {
             let rt = Arc::new(tokio::runtime::Runtime::new().expect("Failed to create runtime"));
-            let source = BigQuerySource::new(rt, &source_conn.conn[..]).unwrap();
+            let source = BigQuerySource::new(rt, &source_conn.conn[..])?;
             let batch_iter = ArrowBatchIter::<_, BigQueryArrowStreamTransport>::new(
                 source,
                 destination,
                 origin_query,
                 queries,
-            )
-            .unwrap();
-            return Box::new(batch_iter);
+            )?;
+            let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+            return iter;
         }
         #[cfg(feature = "src_clickhouse")]
         SourceType::ClickHouse => {
             let rt = Arc::new(tokio::runtime::Runtime::new().expect("Failed to create runtime"));
-            let source = ClickHouseSource::new(rt, &source_conn.conn[..]).unwrap();
+            let source = ClickHouseSource::new(rt, &source_conn.conn[..])?;
             let batch_iter = ArrowBatchIter::<_, ClickHouseArrowStreamTransport>::new(
                 source,
                 destination,
                 origin_query,
                 queries,
-            )
-            .unwrap();
-            return Box::new(batch_iter);
+            )?;
+            let iter: Box<dyn RecordBatchIterator> = Box::new(batch_iter);
+            return iter;
         }
-        _ => {}
+        _ => throw!(ConnectorXOutError::SourceNotSupport(format!(
+            "{:?}",
+            source_conn.ty
+        ))),
     }
-    panic!("not supported!");
 }


### PR DESCRIPTION
## Summary

Partially addresses #909 — `return_type=\"arrow_stream\"` panicked at `connectorx/src/get_arrow.rs:318:22` (or `:355` for cursor) with `PostgresPoolError(Error(None))` whenever the initial Postgres connection setup failed (notably with `sslmode=require`), while the equivalent `return_type=\"arrow\"` succeeded.

The root cause is that `new_record_batch_iter` used `.unwrap()` everywhere, panicking the thread and masking the wrapped r2d2 error. `get_arrow` already returned errors via `#[throws(ConnectorXOutError)]` and `?`; this change brings the streaming path in line.

### Changes

- `connectorx/src/get_arrow.rs` — `new_record_batch_iter` is now `#[throws(ConnectorXOutError)]`; every `.unwrap()` becomes `?`. Returns are typed through `let iter: Box<dyn RecordBatchIterator>` so the unsizing coercion is explicit.
- `connectorx/src/errors.rs` — adds `From<…>` impls on `ConnectorXOutError` for each `*ArrowStream*` transport error so `?` can wrap them.
- `connectorx-python/src/arrow.rs` — propagates the new `Result` with `?` (the surrounding function already returns `ConnectorXPythonError`, which has a `From<ConnectorXOutError>`).
- `connectorx-cpp/src/lib.rs` — keeps current behavior with an explicit `.unwrap()` (FFI boundary; same as the surrounding code).
- `connectorx-python/connectorx/tests/test_postgres.py` — adds a TLS arrow_stream regression test and an explicit “bad host raises” test that exercises the error path.

## Test plan

- [x] `cargo check` + `cargo build --all-features` on the workspace
- [x] `cargo test --lib` (no unit tests defined for this module)
- [ ] CI integration tests against a TLS-enabled Postgres (`POSTGRES_URL_TLS`) — `test_postgres_tls_arrow_stream` and `test_postgres_tls_arrow_stream_bad_host_raises`
- [ ] Manual repro of the issue against AWS RDS with `sslmode=require` to confirm the panic is replaced with a `RuntimeError` carrying the underlying r2d2 message