### PR TITLE
fix(mysql): detect binary vs text columns by charset (charsetnr == 63) instead of BINARY_FLAG

### DIFF
--- a/connectorx-python/connectorx/tests/test_mysql.py
+++ b/connectorx-python/connectorx/tests/test_mysql.py
@@ -336,7 +336,7 @@ def test_mysql_types_binary(mysql_url: str) -> None:
                 dtype="object",
             ),
             "test_mediumtext": pd.Series(
-                [None, b"", b"medium text!!!!"], dtype="object"
+                [None, "", "medium text!!!!"], dtype="object"
             ),
             "test_bit": pd.Series(
                 [b'\x17', b'\x18', None]
@@ -416,7 +416,7 @@ def test_mysql_types_text(mysql_url: str) -> None:
                 dtype="object",
             ),
             "test_mediumtext": pd.Series(
-                [None, b"", b"medium text!!!!"], dtype="object"
+                [None, "", "medium text!!!!"], dtype="object"
             ),
             "test_bit": pd.Series(
                 [b'\x17', b'\x18', None]

--- a/connectorx/src/partition.rs
+++ b/connectorx/src/partition.rs
@@ -282,8 +282,11 @@ fn mysql_get_partition_range(conn: &Url, query: &str, col: &str) -> (i64, i64) {
         .query_first(range_query)?
         .ok_or_else(|| anyhow!("mysql range: no row returns"))?;
 
-    let col_type =
-        MySQLTypeSystem::from((&row.columns()[0].column_type(), &row.columns()[0].flags()));
+    let col_type = MySQLTypeSystem::from((
+        &row.columns()[0].column_type(),
+        &row.columns()[0].flags(),
+        row.columns()[0].character_set(),
+    ));
 
     let (min_v, max_v) = match col_type {
         MySQLTypeSystem::Tiny(_) => {

--- a/connectorx/src/sources/mysql/mod.rs
+++ b/connectorx/src/sources/mysql/mod.rs
@@ -17,14 +17,7 @@ use fehler::{throw, throws};
 use log::{debug, warn};
 use r2d2::{Pool, PooledConnection};
 use r2d2_mysql::{
-    mysql::{
-        consts::{
-            ColumnFlags as MySQLColumnFlags, ColumnType as MySQLColumnType, UTF8MB4_GENERAL_CI,
-            UTF8_GENERAL_CI,
-        },
-        prelude::Queryable,
-        Binary, Opts, OptsBuilder, QueryResult, Row, Text,
-    },
+    mysql::{prelude::Queryable, Binary, Opts, OptsBuilder, QueryResult, Row, Text},
     MySqlConnectionManager,
 };
 use rust_decimal::Decimal;
@@ -109,8 +102,6 @@ where
         assert!(!self.queries.is_empty());
 
         let mut conn = self.pool.get()?;
-        let server_version_post_5_5_3 = conn.server_version() >= (5, 5, 3);
-
         let first_query = &self.queries[0];
 
         match conn.prep(first_query) {
@@ -120,26 +111,11 @@ where
                     .iter()
                     .map(|col| {
                         let col_name = col.name_str().to_string();
-                        let col_type = col.column_type();
-                        let col_flags = col.flags();
-                        let charset = col.character_set();
-                        let charset_is_utf8 = (server_version_post_5_5_3
-                            && charset == UTF8MB4_GENERAL_CI)
-                            || (!server_version_post_5_5_3 && charset == UTF8_GENERAL_CI);
-                        if charset_is_utf8
-                            && (col_type == MySQLColumnType::MYSQL_TYPE_LONG_BLOB
-                                || col_type == MySQLColumnType::MYSQL_TYPE_BLOB
-                                || col_type == MySQLColumnType::MYSQL_TYPE_MEDIUM_BLOB
-                                || col_type == MySQLColumnType::MYSQL_TYPE_TINY_BLOB)
-                        {
-                            return (
-                                col_name,
-                                MySQLTypeSystem::Char(
-                                    !col_flags.contains(MySQLColumnFlags::NOT_NULL_FLAG),
-                                ),
-                            );
-                        }
-                        let d = MySQLTypeSystem::from((&col_type, &col_flags));
+                        let d = MySQLTypeSystem::from((
+                            &col.column_type(),
+                            &col.flags(),
+                            col.character_set(),
+                        ));
                         (col_name, d)
                     })
                     .unzip();
@@ -163,7 +139,11 @@ where
                                 .map(|col| {
                                     (
                                         col.name_str().to_string(),
-                                        MySQLTypeSystem::from((&col.column_type(), &col.flags())),
+                                        MySQLTypeSystem::from((
+                                            &col.column_type(),
+                                            &col.flags(),
+                                            col.character_set(),
+                                        )),
                                     )
                                 })
                                 .unzip();

--- a/connectorx/src/sources/mysql/typesystem.rs
+++ b/connectorx/src/sources/mysql/typesystem.rs
@@ -57,12 +57,20 @@ impl_typesystem! {
     }
 }
 
-impl<'a> From<(&'a ColumnType, &'a ColumnFlags)> for MySQLTypeSystem {
-    fn from(col: (&'a ColumnType, &'a ColumnFlags)) -> MySQLTypeSystem {
+impl<'a> From<(&'a ColumnType, &'a ColumnFlags, u16)> for MySQLTypeSystem {
+    fn from(col: (&'a ColumnType, &'a ColumnFlags, u16)) -> MySQLTypeSystem {
         use MySQLTypeSystem::*;
-        let (ty, flag) = col;
+        let (ty, flag, charset) = col;
         let null_ok = !flag.contains(ColumnFlags::NOT_NULL_FLAG);
         let unsigned = flag.contains(ColumnFlags::UNSIGNED_FLAG);
+
+        // The "binary" pseudo-charset (collation id 63) is the only reliable signal
+        // that a string/blob column holds raw bytes rather than text. BINARY_FLAG is
+        // also set for any *_bin collation (e.g. ascii_bin, utf8mb4_bin), which are
+        // still TEXT columns, so it must not be used to decide binary-ness.
+        const MYSQL_BINARY_CHARSET: u16 = 63;
+        let is_binary = charset == MYSQL_BINARY_CHARSET;
+
         match ty {
             ColumnType::MYSQL_TYPE_TINY => {
                 if unsigned {
@@ -106,17 +114,17 @@ impl<'a> From<(&'a ColumnType, &'a ColumnFlags)> for MySQLTypeSystem {
             ColumnType::MYSQL_TYPE_TIME => Time(null_ok),
             ColumnType::MYSQL_TYPE_DECIMAL => Decimal(null_ok),
             ColumnType::MYSQL_TYPE_NEWDECIMAL => Decimal(null_ok),
+
+            // CHAR/BINARY, VARCHAR/VARBINARY, and TEXT/BLOB share identical type codes, with the actual type determined by the charset.
             ColumnType::MYSQL_TYPE_STRING => {
-                // BINARY/CHAR share the same type code, distinguished by BINARY flag
-                if flag.contains(ColumnFlags::BINARY_FLAG) {
+                if is_binary {
                     TinyBlob(null_ok)
                 } else {
                     Char(null_ok)
                 }
             }
             ColumnType::MYSQL_TYPE_VAR_STRING => {
-                // VARBINARY/VARCHAR share the same type code, distinguished by BINARY flag
-                if flag.contains(ColumnFlags::BINARY_FLAG) {
+                if is_binary {
                     Blob(null_ok)
                 } else {
                     VarChar(null_ok)
@@ -126,10 +134,36 @@ impl<'a> From<(&'a ColumnType, &'a ColumnFlags)> for MySQLTypeSystem {
             ColumnType::MYSQL_TYPE_TIMESTAMP => Timestamp(null_ok),
             ColumnType::MYSQL_TYPE_YEAR => Year(null_ok),
             ColumnType::MYSQL_TYPE_ENUM => Enum(null_ok),
-            ColumnType::MYSQL_TYPE_TINY_BLOB => TinyBlob(null_ok),
-            ColumnType::MYSQL_TYPE_BLOB => Blob(null_ok),
-            ColumnType::MYSQL_TYPE_MEDIUM_BLOB => MediumBlob(null_ok),
-            ColumnType::MYSQL_TYPE_LONG_BLOB => LongBlob(null_ok),
+
+            ColumnType::MYSQL_TYPE_TINY_BLOB => {
+                if is_binary {
+                    TinyBlob(null_ok)
+                } else {
+                    VarChar(null_ok)
+                }
+            } // TINYTEXT
+            ColumnType::MYSQL_TYPE_BLOB => {
+                if is_binary {
+                    Blob(null_ok)
+                } else {
+                    VarChar(null_ok)
+                }
+            } // TEXT
+            ColumnType::MYSQL_TYPE_MEDIUM_BLOB => {
+                if is_binary {
+                    MediumBlob(null_ok)
+                } else {
+                    VarChar(null_ok)
+                }
+            } // MEDIUMTEXT
+            ColumnType::MYSQL_TYPE_LONG_BLOB => {
+                if is_binary {
+                    LongBlob(null_ok)
+                } else {
+                    VarChar(null_ok)
+                }
+            } // LONGTEXT
+
             ColumnType::MYSQL_TYPE_JSON => Json(null_ok),
             ColumnType::MYSQL_TYPE_VARCHAR => VarChar(null_ok),
             ColumnType::MYSQL_TYPE_BIT => Bit(null_ok),

--- a/connectorx/tests/test_mysql.rs
+++ b/connectorx/tests/test_mysql.rs
@@ -4,6 +4,7 @@ mod test_db;
 
 use arrow::{
     array::{Float64Array, Int16Array, Int32Array, Int64Array, StringArray, UInt64Array},
+    datatypes::DataType,
     record_batch::RecordBatch,
 };
 use connectorx::{
@@ -229,77 +230,100 @@ pub fn verify_arrow_results(result: Vec<RecordBatch>) {
     }
 }
 
-// Unit tests for BINARY_FLAG detection logic
-// These tests don't require a database connection
+// Unit tests for MySQL binary-vs-text type detection (no DB required).
+// Detection keys on the "binary" charset (collation id 63), not BINARY_FLAG:
+// charset 63 => binary data (BINARY/VARBINARY/BLOB), any other id => text.
+// Charset ids used below: 63 = binary, 45 = utf8mb4_general_ci, 46 = utf8mb4_bin, 65 = ascii_bin.
 
 use connectorx::sources::mysql::MySQLTypeSystem;
 use r2d2_mysql::mysql::consts::{ColumnFlags, ColumnType};
 
-/// Test that BINARY_FLAG correctly distinguishes BINARY from CHAR
+/// BINARY shares its type code with CHAR (MYSQL_TYPE_STRING). The binary charset
+/// (63) is what marks it as binary, so it must map to TinyBlob, not Char.
 #[test]
-fn test_mysql_binary_flag_for_binary_type() {
-    // Simulate BINARY(10): MYSQL_TYPE_STRING + BINARY_FLAG
-    let col_type = ColumnType::MYSQL_TYPE_STRING;
-    let mut flags = ColumnFlags::empty();
-    flags.insert(ColumnFlags::BINARY_FLAG);
-
-    let result = MySQLTypeSystem::from((&col_type, &flags));
-
-    // Should be TinyBlob (Vec<u8>), not Char (String)
-    // This prevents "Could not convert Bytes(...) to desired type" panic
-    match result {
-        MySQLTypeSystem::TinyBlob(true) => {} // OK
-        _ => panic!("BINARY should map to TinyBlob, got {:?}", result),
+fn test_binary_is_binary() {
+    let mut f = ColumnFlags::empty();
+    f.insert(ColumnFlags::BINARY_FLAG);
+    match MySQLTypeSystem::from((&ColumnType::MYSQL_TYPE_STRING, &f, 63)) {
+        MySQLTypeSystem::TinyBlob(true) => {}
+        o => panic!("BINARY should be TinyBlob, got {:?}", o),
     }
 }
 
-/// Test that CHAR without BINARY_FLAG maps to Char
+/// CHAR uses a real (non-binary) charset, so MYSQL_TYPE_STRING maps to Char.
 #[test]
-fn test_mysql_binary_flag_for_char_type() {
-    // Simulate CHAR(10): MYSQL_TYPE_STRING without BINARY_FLAG
-    let col_type = ColumnType::MYSQL_TYPE_STRING;
-    let flags = ColumnFlags::empty();
-
-    let result = MySQLTypeSystem::from((&col_type, &flags));
-
-    // Should be Char (String), not TinyBlob (Vec<u8>)
-    match result {
-        MySQLTypeSystem::Char(true) => {} // OK
-        _ => panic!("CHAR should map to Char, got {:?}", result),
+fn test_char_is_text() {
+    match MySQLTypeSystem::from((&ColumnType::MYSQL_TYPE_STRING, &ColumnFlags::empty(), 45)) {
+        MySQLTypeSystem::Char(true) => {}
+        o => panic!("CHAR should be Char, got {:?}", o),
     }
 }
 
-/// Test that BINARY_FLAG correctly distinguishes VARBINARY from VARCHAR
+/// VARBINARY shares its type code with VARCHAR (MYSQL_TYPE_VAR_STRING). The binary
+/// charset (63) marks it as binary, so it must map to Blob, not VarChar.
 #[test]
-fn test_mysql_binary_flag_for_varbinary_type() {
-    // Simulate VARBINARY(10): MYSQL_TYPE_VAR_STRING + BINARY_FLAG
-    let col_type = ColumnType::MYSQL_TYPE_VAR_STRING;
-    let mut flags = ColumnFlags::empty();
-    flags.insert(ColumnFlags::BINARY_FLAG);
-
-    let result = MySQLTypeSystem::from((&col_type, &flags));
-
-    // Should be Blob (Vec<u8>), not VarChar (String)
-    // This prevents "Could not convert Bytes(...) to desired type" panic
-    match result {
-        MySQLTypeSystem::Blob(true) => {} // OK
-        _ => panic!("VARBINARY should map to Blob, got {:?}", result),
+fn test_varbinary_is_binary() {
+    let mut f = ColumnFlags::empty();
+    f.insert(ColumnFlags::BINARY_FLAG);
+    match MySQLTypeSystem::from((&ColumnType::MYSQL_TYPE_VAR_STRING, &f, 63)) {
+        MySQLTypeSystem::Blob(true) => {}
+        o => panic!("VARBINARY should be Blob, got {:?}", o),
     }
 }
 
-/// Test that VARCHAR without BINARY_FLAG maps to VarChar
+/// VARCHAR uses a real (non-binary) charset, so MYSQL_TYPE_VAR_STRING maps to VarChar.
 #[test]
-fn test_mysql_binary_flag_for_varchar_type() {
-    // Simulate VARCHAR(10): MYSQL_TYPE_VAR_STRING without BINARY_FLAG
-    let col_type = ColumnType::MYSQL_TYPE_VAR_STRING;
-    let flags = ColumnFlags::empty();
+fn test_varchar_is_text() {
+    match MySQLTypeSystem::from((
+        &ColumnType::MYSQL_TYPE_VAR_STRING,
+        &ColumnFlags::empty(),
+        45,
+    )) {
+        MySQLTypeSystem::VarChar(true) => {}
+        o => panic!("VARCHAR should be VarChar, got {:?}", o),
+    }
+}
 
-    let result = MySQLTypeSystem::from((&col_type, &flags));
+/// Regression: a *_bin collation sets BINARY_FLAG but the column is still text.
+/// charset != 63 must win over the flag, so VARCHAR ... COLLATE *_bin => VarChar.
+#[test]
+fn test_varchar_bin_collation_is_text() {
+    let mut f = ColumnFlags::empty();
+    f.insert(ColumnFlags::BINARY_FLAG); // *_bin collations DO set BINARY_FLAG
+    match MySQLTypeSystem::from((&ColumnType::MYSQL_TYPE_VAR_STRING, &f, 65)) {
+        MySQLTypeSystem::VarChar(true) => {}
+        o => panic!("VARCHAR COLLATE *_bin must be VarChar, got {:?}", o),
+    }
+}
 
-    // Should be VarChar (String), not Blob (Vec<u8>)
-    match result {
-        MySQLTypeSystem::VarChar(true) => {} // OK
-        _ => panic!("VARCHAR should map to VarChar, got {:?}", result),
+/// CHAR ... COLLATE *_bin is still text (charset != 63), despite BINARY_FLAG.
+#[test]
+fn test_char_bin_collation_is_text() {
+    let mut f = ColumnFlags::empty();
+    f.insert(ColumnFlags::BINARY_FLAG);
+    match MySQLTypeSystem::from((&ColumnType::MYSQL_TYPE_STRING, &f, 46)) {
+        MySQLTypeSystem::Char(true) => {}
+        o => panic!("CHAR COLLATE *_bin must be Char, got {:?}", o),
+    }
+}
+
+/// TEXT shares its type code with BLOB; a *_bin collation (charset != 63) is still text.
+#[test]
+fn test_text_bin_collation_is_text() {
+    let mut f = ColumnFlags::empty();
+    f.insert(ColumnFlags::BINARY_FLAG);
+    match MySQLTypeSystem::from((&ColumnType::MYSQL_TYPE_BLOB, &f, 46)) {
+        MySQLTypeSystem::VarChar(true) => {}
+        o => panic!("TEXT COLLATE *_bin must be text, got {:?}", o),
+    }
+}
+
+/// BLOB has the binary charset (63), so it must map to Blob.
+#[test]
+fn test_blob_is_binary() {
+    match MySQLTypeSystem::from((&ColumnType::MYSQL_TYPE_BLOB, &ColumnFlags::empty(), 63)) {
+        MySQLTypeSystem::Blob(true) => {}
+        o => panic!("BLOB should be Blob, got {:?}", o),
     }
 }
 
@@ -427,4 +451,85 @@ fn test_mysql_bigint_unsigned_not_float_text() {
         .unwrap();
 
     assert_eq!(col.value(0), 0u64);
+}
+
+fn assert_str_collation_schema(result: &[RecordBatch]) {
+    let schema = result[0].schema();
+
+    // Text columns, including *_bin collations, must be UTF-8 strings (not binary).
+    for col in ["vc_general", "vc_bin", "vc_ascii", "txt_general", "txt_bin"] {
+        let dt = schema.field_with_name(col).unwrap().data_type();
+        assert!(
+            matches!(dt, DataType::Utf8 | DataType::LargeUtf8),
+            "{} should be a string type, got {:?}",
+            col,
+            dt
+        );
+    }
+
+    // Genuine binary types must stay binary.
+    for col in ["vb", "bin_col", "bl"] {
+        let dt = schema.field_with_name(col).unwrap().data_type();
+        assert!(
+            matches!(dt, DataType::Binary | DataType::LargeBinary),
+            "{} should be a binary type, got {:?}",
+            col,
+            dt
+        );
+    }
+}
+
+#[test]
+fn test_mysql_string_collation_types() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let dburl = test_db::mysql_url();
+
+    let queries = [CXQuery::naked(
+        "SELECT vc_general, vc_bin, vc_ascii, txt_general, txt_bin, vb, bin_col, bl \
+         FROM test_str_collation ORDER BY test_id",
+    )];
+
+    let builder = MySQLSource::<BinaryProtocol>::new(&dburl, 1).unwrap();
+    let mut destination = ArrowDestination::new();
+    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<BinaryProtocol>>::new(
+        builder,
+        &mut destination,
+        &queries,
+        None,
+    );
+    dispatcher.run().unwrap();
+
+    let result = destination.arrow().unwrap();
+    assert_eq!(result.len(), 1);
+
+    // Text columns (including *_bin collations) must map to strings; only the
+    // binary charset (charsetnr == 63) is binary. Guards against the regression
+    // where BINARY_FLAG-based detection turned *_bin text into LargeBinary.
+    assert_str_collation_schema(&result);
+}
+
+#[test]
+fn test_mysql_string_collation_types_text() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let dburl = test_db::mysql_url();
+
+    let queries = [CXQuery::naked(
+        "SELECT vc_general, vc_bin, vc_ascii, txt_general, txt_bin, vb, bin_col, bl \
+         FROM test_str_collation ORDER BY test_id",
+    )];
+
+    let builder = MySQLSource::<TextProtocol>::new(&dburl, 1).unwrap();
+    let mut destination = ArrowDestination::new();
+    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<TextProtocol>>::new(
+        builder,
+        &mut destination,
+        &queries,
+        None,
+    );
+    dispatcher.run().unwrap();
+
+    let result = destination.arrow().unwrap();
+    assert_eq!(result.len(), 1);
+
+    assert_str_collation_schema(&result);
 }

--- a/connectorx/tests/test_mysql.rs
+++ b/connectorx/tests/test_mysql.rs
@@ -3,7 +3,7 @@
 mod test_db;
 
 use arrow::{
-    array::{Float64Array, Int16Array, Int32Array, Int64Array, StringArray, UInt64Array},
+    array::{Float64Array, Int16Array, Int32Array, StringArray, UInt64Array},
     datatypes::DataType,
     record_batch::RecordBatch,
 };

--- a/scripts/mysql.sql
+++ b/scripts/mysql.sql
@@ -70,3 +70,23 @@ CREATE TABLE IF NOT EXISTS test_types(
 INSERT INTO test_types VALUES ('1970-01-01 00:00:01', NULL, '00:00:00', '1970-01-01 00:00:01', 1.1, 1, NULL, 'char1', -128, -32768, -8388608, -2147483648, -9223372036854775808, NULL, NULL, NULL, NULL, NULL, 1, 1, NULL, -2.2E-308, 1.2345, 1901, NULL, NULL, NULL, NULL, NULL, NULL, 'apple', '{"name": "piggy", "age": 1}', NULL, b'10111');
 INSERT INTO test_types VALUES ('2038-01-19 00:00:00', '1970-01-01', NULL, '9999-12-31 14:30:00', NULL, 2, 'varchar2', NULL, 127, 32767, 8388607, 2147483647, 9223372036854775807, 255, 65535, 16777215, 4294967295, 1.844674407E19, 2147483647, 65535, -1.1E-38, NULL, -1.1E-3, 2155, 0x4D7953514C42696E6172, 0x4442, 'tinyblob2', 'blobblobblobblob2', 'mediumblob2', 'longblob2', NULL, '{"name": "kitty", "age": 2}', '', b'11000');
 INSERT INTO test_types VALUES (NULL, '9999-12-31', '23:59:59', NULL, 3.3, NULL, 'varchar3', 'char3', NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, 0, -2147483648, 0, 3.4E38, 1.7E308, 1.7E30, NULL, 0x00010203, 0x00, 'tinyblob3', 'blobblobblobblob3', 'mediumblob3', 'longblob3', 'mango', NULL, 'medium text!!!!', NULL);
+
+DROP TABLE IF EXISTS test_str_collation;
+
+-- Regression coverage for binary-vs-text detection.
+-- A *_bin collation sets BINARY_FLAG but the column is still text; only the
+-- "binary" charset (collation id 63) means binary data. Detection must key on
+-- charsetnr == 63, not BINARY_FLAG.
+CREATE TABLE IF NOT EXISTS test_str_collation (
+    test_id     INT,
+    vc_general  VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    vc_bin      VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
+    vc_ascii    VARCHAR(20) CHARACTER SET ascii   COLLATE ascii_bin,
+    txt_general TEXT        CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    txt_bin     TEXT        CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
+    vb          VARBINARY(20),
+    bin_col     BINARY(4),
+    bl          BLOB
+);
+
+INSERT INTO test_str_collation VALUES (1, 'general', 'bin', 'ascii', 'text', 'textbin', 0x4442, 0x00010203, 'blob'), (2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
## Summary

MySQL `CHAR`/`VARCHAR`/`TEXT` columns that use a `*_bin` collation (e.g. `ascii_bin`, `utf8mb4_bin`) are incorrectly returned as binary (Arrow `large_binary`) instead of strings.

The binary-vs-text decision in the MySQL source relied on `ColumnFlags::BINARY_FLAG`, but that flag is set for any column using a binary (`_bin`) collation — which are still **text** columns. This PR switches the decision to the only reliable signal, the **binary charset (collation id 63)**, and removes a related, fragile `charset == utf8mb4_general_ci` special case.

## Reproduction

```sql
CREATE TABLE cx_typetest (
  vc_ci    VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
  vc_bin   VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
  vc_ascii VARCHAR(20) CHARACTER SET ascii   COLLATE ascii_bin,
  txt_ci   TEXT        CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
  txt_bin  TEXT        CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
  vb       VARBINARY(20),
  bl       BLOB
);
```

Arrow schema from `cx.read_sql(url, "SELECT * FROM cx_typetest", return_type="arrow")` (MySQL 8.0, utf8mb4 connection):

| column | definition | 0.4.5 | 0.4.6-alpha.1 | this PR |
|---|---|---|---|---|
| vc_ci | VARCHAR utf8mb4_general_ci | string | string | string |
| vc_bin | VARCHAR utf8mb4_bin | string | **large_binary** ❌ | string ✅ |
| vc_ascii | VARCHAR ascii_bin | string | **large_binary** ❌ | string ✅ |
| txt_ci | TEXT utf8mb4_general_ci | string | string | string |
| txt_bin | TEXT utf8mb4_bin | string | string | string |
| vb | VARBINARY | **string** ❌ | large_binary | large_binary |
| bl | BLOB | large_binary | large_binary | large_binary |

- **0.4.5**: `VARBINARY` was wrongly returned as `string`.
- **0.4.6-alpha.1** (fixed `BINARY`/`VARBINARY` in e708b11): correct for `vb`, but introduced a regression — `CHAR`/`VARCHAR` with a `*_bin` collation are now returned as binary.
- **This PR**: `*_bin` text columns are strings again, while `VARBINARY`/`BLOB` stay binary. It is a strict superset of the e708b11 fix.

## Root cause

1. e708b11 distinguished `BINARY`/`VARBINARY` from `CHAR`/`VARCHAR` (which share the `MYSQL_TYPE_STRING` / `MYSQL_TYPE_VAR_STRING` type codes) using `ColumnFlags::BINARY_FLAG`. But `BINARY_FLAG` indicates the column uses a binary (`_bin`) **collation**, not that it stores binary data — `ascii_bin` / `utf8mb4_bin` columns set the flag yet hold text.
2. `fetch_metadata` separately treated `*_BLOB` columns as text only when `charset == UTF8MB4_GENERAL_CI`. The result `charsetnr` depends on the negotiated connection collation (e.g. `utf8mb4_0900_ai_ci` = 255 on MySQL 8.0 vs `utf8mb4_general_ci` = 45), so under other connection collations TEXT columns could also fall through to binary.

## Why `charsetnr == 63`

MySQL documents charset id 63 (the `binary` charset) as the canonical way to tell binary data from text in result metadata. The [C API Developer Guide](https://dev.mysql.com/doc/c-api/8.0/en/c-api-prepared-statement-type-conversions.html) specifies that a `charsetnr` of 63 is what distinguishes `BINARY` from `CHAR`, `VARBINARY` from `VARCHAR`, and the `BLOB` types from the `TEXT` types (see also [C API Basic Data Structures](https://dev.mysql.com/doc/c-api/8.0/en/c-api-data-structures.html) for `MYSQL_FIELD.charsetnr`).

Per [Reference Manual §13.3.3](https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html), `CHAR BINARY` / `VARCHAR BINARY` (i.e. a `_bin` collation) still store *nonbinary character strings* — they are text, distinct from the `BINARY`/`VARBINARY` data types. So `BINARY_FLAG` (the `_bin` attribute) is the wrong discriminator; the binary charset (63) is the right one. The same mistake has surfaced in other Rust MySQL drivers (e.g. [sqlx#3387](https://github.com/launchbadge/sqlx/issues/3387)).

## Changes

- `sources/mysql/typesystem.rs`: thread the column charset into `MySQLTypeSystem::from`; `MYSQL_TYPE_STRING` / `MYSQL_TYPE_VAR_STRING` and the four `*_BLOB` (TEXT/BLOB) arms now map to a binary type iff `charsetnr == 63`, otherwise to text.
- `sources/mysql/mod.rs`: pass `col.character_set()` at both `fetch_metadata` call sites; remove the now-redundant `charset == UTF8MB4_GENERAL_CI` special case (and the unused server-version check).
- `partition.rs`: update the `mysql_get_partition_range` call site.

## Tests

- Unit tests (no DB) for the type mapping: `BINARY`/`VARBINARY`/`BLOB` (charset 63) → binary; `CHAR`/`VARCHAR`/`TEXT` → text; and `*_bin` text columns → text despite `BINARY_FLAG` being set.
- Integration test against a new `test_str_collation` table asserting the Arrow schema (string vs binary) for both the binary and text protocols.

### Updated test_mediumtext expectations from bytes to str

MEDIUMTEXT is a text type and was previously returned as binary because the charset == utf8mb4_general_ci special case did not match the CI connection collation (utf8mb4_0900_ai_ci). This is exactly the fragility this PR removes.