### PR TITLE
feat(mysql): preserve narrow integer and float types in Arrow transports

### DIFF
--- a/connectorx/src/destinations/arrow/arrow_assoc.rs
+++ b/connectorx/src/destinations/arrow/arrow_assoc.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 use arrow::array::{
     ArrayBuilder, BooleanBuilder, Date32Builder, Decimal128Builder, Float32Builder, Float64Builder,
-    Int16Builder, Int32Builder, Int64Builder, LargeBinaryBuilder, LargeListBuilder, StringBuilder,
-    Time64MicrosecondBuilder, Time64NanosecondBuilder, TimestampMicrosecondBuilder,
-    TimestampNanosecondBuilder, UInt16Builder, UInt32Builder, UInt64Builder,
+    Int16Builder, Int32Builder, Int64Builder, Int8Builder, LargeBinaryBuilder, LargeListBuilder,
+    StringBuilder, Time64MicrosecondBuilder, Time64NanosecondBuilder, TimestampMicrosecondBuilder,
+    TimestampNanosecondBuilder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
 };
 use arrow::datatypes::Field;
 use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
@@ -65,9 +65,11 @@ macro_rules! impl_arrow_assoc {
     };
 }
 
+impl_arrow_assoc!(u8, ArrowDataType::UInt8, UInt8Builder);
 impl_arrow_assoc!(u16, ArrowDataType::UInt16, UInt16Builder);
 impl_arrow_assoc!(u32, ArrowDataType::UInt32, UInt32Builder);
 impl_arrow_assoc!(u64, ArrowDataType::UInt64, UInt64Builder);
+impl_arrow_assoc!(i8, ArrowDataType::Int8, Int8Builder);
 impl_arrow_assoc!(i16, ArrowDataType::Int16, Int16Builder);
 impl_arrow_assoc!(i32, ArrowDataType::Int32, Int32Builder);
 impl_arrow_assoc!(i64, ArrowDataType::Int64, Int64Builder);

--- a/connectorx/src/destinations/arrow/typesystem.rs
+++ b/connectorx/src/destinations/arrow/typesystem.rs
@@ -13,9 +13,11 @@ pub struct NaiveDateTimeWrapperMicro(pub NaiveDateTime);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ArrowTypeSystem {
+    Int8(bool),
     Int16(bool),
     Int32(bool),
     Int64(bool),
+    UInt8(bool),
     UInt16(bool),
     UInt32(bool),
     UInt64(bool),
@@ -48,9 +50,11 @@ pub enum ArrowTypeSystem {
 impl_typesystem! {
     system = ArrowTypeSystem,
     mappings = {
+        { Int8            => i8                        }
         { Int16           => i16                       }
         { Int32           => i32                       }
         { Int64           => i64                       }
+        { UInt8           => u8                        }
         { UInt16          => u16                       }
         { UInt32          => u32                       }
         { UInt64          => u64                       }

--- a/connectorx/src/destinations/arrowstream/arrow_assoc.rs
+++ b/connectorx/src/destinations/arrowstream/arrow_assoc.rs
@@ -6,9 +6,9 @@ use crate::constants::{DEFAULT_ARROW_DECIMAL, DEFAULT_ARROW_DECIMAL_SCALE, SECON
 use crate::utils::decimal_to_i128;
 use arrow::array::{
     ArrayBuilder, BooleanBuilder, Date32Builder, Decimal128Builder, Float32Builder, Float64Builder,
-    Int16Builder, Int32Builder, Int64Builder, LargeBinaryBuilder, LargeListBuilder, StringBuilder,
-    Time64MicrosecondBuilder, Time64NanosecondBuilder, TimestampMicrosecondBuilder,
-    TimestampNanosecondBuilder, UInt16Builder, UInt32Builder, UInt64Builder,
+    Int16Builder, Int32Builder, Int64Builder, Int8Builder, LargeBinaryBuilder, LargeListBuilder,
+    StringBuilder, Time64MicrosecondBuilder, Time64NanosecondBuilder, TimestampMicrosecondBuilder,
+    TimestampNanosecondBuilder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
 };
 use arrow::datatypes::Field;
 use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
@@ -62,9 +62,11 @@ macro_rules! impl_arrow_assoc {
     };
 }
 
+impl_arrow_assoc!(u8, ArrowDataType::UInt8, UInt8Builder);
 impl_arrow_assoc!(u16, ArrowDataType::UInt16, UInt16Builder);
 impl_arrow_assoc!(u32, ArrowDataType::UInt32, UInt32Builder);
 impl_arrow_assoc!(u64, ArrowDataType::UInt64, UInt64Builder);
+impl_arrow_assoc!(i8, ArrowDataType::Int8, Int8Builder);
 impl_arrow_assoc!(i16, ArrowDataType::Int16, Int16Builder);
 impl_arrow_assoc!(i32, ArrowDataType::Int32, Int32Builder);
 impl_arrow_assoc!(i64, ArrowDataType::Int64, Int64Builder);

--- a/connectorx/src/destinations/arrowstream/typesystem.rs
+++ b/connectorx/src/destinations/arrowstream/typesystem.rs
@@ -13,9 +13,11 @@ pub struct NaiveDateTimeWrapperMicro(pub NaiveDateTime);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ArrowTypeSystem {
+    Int8(bool),
     Int16(bool),
     Int32(bool),
     Int64(bool),
+    UInt8(bool),
     UInt16(bool),
     UInt32(bool),
     UInt64(bool),
@@ -48,9 +50,11 @@ pub enum ArrowTypeSystem {
 impl_typesystem! {
     system = ArrowTypeSystem,
     mappings = {
+        { Int8            => i8                        }
         { Int16           => i16                       }
         { Int32           => i32                       }
         { Int64           => i64                       }
+        { UInt8           => u8                        }
         { UInt16          => u16                       }
         { UInt32          => u32                       }
         { UInt64          => u64                       }

--- a/connectorx/src/transports/mysql_arrow.rs
+++ b/connectorx/src/transports/mysql_arrow.rs
@@ -39,14 +39,14 @@ impl_transport!(
     systems = MySQLTypeSystem => ArrowTypeSystem,
     route = MySQLSource<BinaryProtocol> => ArrowDestination,
     mappings = {
-        { Float[f32]                 => Float64[f64]            | conversion auto }
+        { Float[f32]                 => Float32[f32]            | conversion auto }
         { Double[f64]                => Float64[f64]            | conversion auto }
-        { Tiny[i8]                   => Int16[i16]              | conversion auto }
+        { Tiny[i8]                   => Int8[i8]                | conversion auto }
         { Short[i16]                 => Int16[i16]              | conversion auto }
         { Int24[i32]                 => Int32[i32]              | conversion none }
         { Long[i32]                  => Int32[i32]              | conversion auto }
         { LongLong[i64]              => Int64[i64]              | conversion auto }
-        { UTiny[u8]                  => UInt16[u16]             | conversion auto }
+        { UTiny[u8]                  => UInt8[u8]               | conversion auto }
         { UShort[u16]                => UInt16[u16]             | conversion auto }
         { UInt24[u32]                => UInt32[u32]             | conversion none }
         { ULong[u32]                 => UInt32[u32]             | conversion auto }
@@ -75,14 +75,14 @@ impl_transport!(
     systems = MySQLTypeSystem => ArrowTypeSystem,
     route = MySQLSource<TextProtocol> => ArrowDestination,
     mappings = {
-        { Float[f32]                 => Float64[f64]            | conversion auto }
+        { Float[f32]                 => Float32[f32]            | conversion auto }
         { Double[f64]                => Float64[f64]            | conversion auto }
-        { Tiny[i8]                   => Int16[i16]              | conversion auto }
+        { Tiny[i8]                   => Int8[i8]                | conversion auto }
         { Short[i16]                 => Int16[i16]              | conversion auto }
         { Int24[i32]                 => Int32[i32]              | conversion none }
         { Long[i32]                  => Int32[i32]              | conversion auto }
         { LongLong[i64]              => Int64[i64]              | conversion auto }
-        { UTiny[u8]                  => UInt16[u16]             | conversion auto }
+        { UTiny[u8]                  => UInt8[u8]               | conversion auto }
         { UShort[u16]                => UInt16[u16]             | conversion auto }
         { UInt24[u32]                => UInt32[u32]             | conversion none }
         { ULong[u32]                 => UInt32[u32]             | conversion auto }

--- a/connectorx/src/transports/mysql_arrowstream.rs
+++ b/connectorx/src/transports/mysql_arrowstream.rs
@@ -39,22 +39,22 @@ impl_transport!(
     systems = MySQLTypeSystem => ArrowTypeSystem,
     route = MySQLSource<BinaryProtocol> => ArrowDestination,
     mappings = {
-        { Float[f32]                 => Float64[f64]            | conversion auto }
+        { Float[f32]                 => Float32[f32]            | conversion auto }
         { Double[f64]                => Float64[f64]            | conversion auto }
-        { Tiny[i8]                   => Int16[i16]              | conversion auto }
-        { Short[i16]                 => Int64[i64]              | conversion auto }
-        { Int24[i32]                 => Int64[i64]              | conversion none }
-        { Long[i32]                  => Int64[i64]              | conversion auto }
+        { Tiny[i8]                   => Int8[i8]                | conversion auto }
+        { Short[i16]                 => Int16[i16]              | conversion auto }
+        { Int24[i32]                 => Int32[i32]              | conversion none }
+        { Long[i32]                  => Int32[i32]              | conversion auto }
         { LongLong[i64]              => Int64[i64]              | conversion auto }
-        { UTiny[u8]                  => Int64[i64]              | conversion auto }
-        { UShort[u16]                => Int64[i64]              | conversion auto }
-        { ULong[u32]                 => Int64[i64]              | conversion auto }
-        { UInt24[u32]                => Int64[i64]              | conversion none }
+        { UTiny[u8]                  => UInt8[u8]               | conversion auto }
+        { UShort[u16]                => UInt16[u16]             | conversion auto }
+        { UInt24[u32]                => UInt32[u32]             | conversion none }
+        { ULong[u32]                 => UInt32[u32]             | conversion auto }
         { ULongLong[u64]             => UInt64[u64]             | conversion auto }
         { Date[NaiveDate]            => Date32[NaiveDate]       | conversion auto }
         { Time[NaiveTime]            => Time64Micro[NaiveTimeWrapperMicro]       | conversion option }
         { Datetime[NaiveDateTime]    => Date64Micro[NaiveDateTimeWrapperMicro]   | conversion option }
-        { Year[i16]                  => Int64[i64]              | conversion none}
+        { Year[i16]                  => Int16[i16]              | conversion none }
         { Timestamp[NaiveDateTime]   => Date64Micro[NaiveDateTimeWrapperMicro]   | conversion none }
         { Decimal[Decimal]           => Decimal[Decimal]        | conversion auto }
         { VarChar[String]            => LargeUtf8[String]       | conversion auto }
@@ -75,22 +75,22 @@ impl_transport!(
     systems = MySQLTypeSystem => ArrowTypeSystem,
     route = MySQLSource<TextProtocol> => ArrowDestination,
     mappings = {
-        { Float[f32]                 => Float64[f64]            | conversion auto }
+        { Float[f32]                 => Float32[f32]            | conversion auto }
         { Double[f64]                => Float64[f64]            | conversion auto }
-        { Tiny[i8]                   => Int16[i16]              | conversion auto }
-        { Short[i16]                 => Int64[i64]              | conversion auto }
-        { Int24[i32]                 => Int64[i64]              | conversion none }
-        { Long[i32]                  => Int64[i64]              | conversion auto }
+        { Tiny[i8]                   => Int8[i8]                | conversion auto }
+        { Short[i16]                 => Int16[i16]              | conversion auto }
+        { Int24[i32]                 => Int32[i32]              | conversion none }
+        { Long[i32]                  => Int32[i32]              | conversion auto }
         { LongLong[i64]              => Int64[i64]              | conversion auto }
-        { UTiny[u8]                  => Int64[i64]              | conversion auto }
-        { UShort[u16]                => Int64[i64]              | conversion auto }
-        { ULong[u32]                 => Int64[i64]              | conversion auto }
-        { UInt24[u32]                => Int64[i64]              | conversion none }
+        { UTiny[u8]                  => UInt8[u8]               | conversion auto }
+        { UShort[u16]                => UInt16[u16]             | conversion auto }
+        { UInt24[u32]                => UInt32[u32]             | conversion none }
+        { ULong[u32]                 => UInt32[u32]             | conversion auto }
         { ULongLong[u64]             => UInt64[u64]             | conversion auto }
         { Date[NaiveDate]            => Date32[NaiveDate]       | conversion auto }
         { Time[NaiveTime]            => Time64Micro[NaiveTimeWrapperMicro]       | conversion option }
         { Datetime[NaiveDateTime]    => Date64Micro[NaiveDateTimeWrapperMicro]   | conversion option }
-        { Year[i16]                  => Int64[i64]              | conversion none}
+        { Year[i16]                  => Int16[i16]              | conversion none }
         { Timestamp[NaiveDateTime]   => Date64Micro[NaiveDateTimeWrapperMicro]   | conversion none }
         { Decimal[Decimal]           => Decimal[Decimal]        | conversion auto }
         { VarChar[String]            => LargeUtf8[String]       | conversion auto }

--- a/connectorx/tests/test_mysql.rs
+++ b/connectorx/tests/test_mysql.rs
@@ -3,7 +3,10 @@
 mod test_db;
 
 use arrow::{
-    array::{Float64Array, Int16Array, Int32Array, StringArray, UInt64Array},
+    array::{
+        Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, StringArray,
+        UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    },
     datatypes::DataType,
     record_batch::RecordBatch,
 };
@@ -93,7 +96,7 @@ fn test_mysql_pre_execution_queries() {
 
     let result = destination.arrow().unwrap();
 
-    assert!(result.len() == 1);
+    assert_eq!(result.len(), 1);
 
     assert!(result[0]
         .column(0)
@@ -329,87 +332,45 @@ fn test_blob_is_binary() {
 
 #[test]
 fn test_mysql_tinyint_not_bool() {
-    let _ = env_logger::builder().is_test(true).try_init();
-    let dburl = test_db::mysql_url();
-
-    let queries = [CXQuery::naked(
+    let result = run_mysql_query(
         "SELECT test_tiny FROM test_types WHERE test_tiny IS NOT NULL ORDER BY test_tiny",
-    )];
-
-    let builder = MySQLSource::<BinaryProtocol>::new(&dburl, 1).unwrap();
-    let mut destination = ArrowDestination::new();
-    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<BinaryProtocol>>::new(
-        builder,
-        &mut destination,
-        &queries,
-        None,
+        true,
     );
-    dispatcher.run().unwrap();
+    assert_eq!(result.len(), 1);
 
-    let result = destination.arrow().unwrap();
-    assert!(result.len() == 1);
-
-    // TINYINT values must be preserved as Int16, not collapsed to Boolean.
+    // TINYINT values must be preserved as Int8, not collapsed to Boolean.
     // Before this fix, -128 and 127 would both become `true`.
     assert!(result[0]
         .column(0)
         .as_any()
-        .downcast_ref::<Int16Array>()
+        .downcast_ref::<Int8Array>()
         .unwrap()
-        .eq(&Int16Array::from(vec![-128i16, 127])));
+        .eq(&Int8Array::from(vec![-128i8, 127])));
 }
 
 #[test]
 fn test_mysql_tinyint_not_bool_text() {
-    let _ = env_logger::builder().is_test(true).try_init();
-    let dburl = test_db::mysql_url();
-
-    let queries = [CXQuery::naked(
+    let result = run_mysql_query(
         "SELECT test_tiny FROM test_types WHERE test_tiny IS NOT NULL ORDER BY test_tiny",
-    )];
-
-    let builder = MySQLSource::<TextProtocol>::new(&dburl, 1).unwrap();
-    let mut destination = ArrowDestination::new();
-    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<TextProtocol>>::new(
-        builder,
-        &mut destination,
-        &queries,
-        None,
+        false,
     );
-    dispatcher.run().unwrap();
-
-    let result = destination.arrow().unwrap();
-    assert!(result.len() == 1);
+    assert_eq!(result.len(), 1);
 
     assert!(result[0]
         .column(0)
         .as_any()
-        .downcast_ref::<Int16Array>()
+        .downcast_ref::<Int8Array>()
         .unwrap()
-        .eq(&Int16Array::from(vec![-128i16, 127])));
+        .eq(&Int8Array::from(vec![-128i8, 127])));
 }
 
 #[test]
 fn test_mysql_bigint_unsigned_not_float() {
-    let _ = env_logger::builder().is_test(true).try_init();
-    let dburl = test_db::mysql_url();
-
-    let queries = [CXQuery::naked(
+    let result = run_mysql_query(
         "SELECT test_longlong_unsigned FROM test_types WHERE test_longlong_unsigned IS NOT NULL ORDER BY test_longlong_unsigned",
-    )];
-
-    let builder = MySQLSource::<BinaryProtocol>::new(&dburl, 1).unwrap();
-    let mut destination = ArrowDestination::new();
-    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<BinaryProtocol>>::new(
-        builder,
-        &mut destination,
-        &queries,
-        None,
+        true,
     );
-    dispatcher.run().unwrap();
-
-    let result = destination.arrow().unwrap();
-    assert!(result.len() == 1);
+    assert_eq!(result.len(), 1);
 
     // BIGINT UNSIGNED must be UInt64, not Float64.
     // Float64 loses precision for values exceeding 2^53 (see #890).
@@ -424,25 +385,11 @@ fn test_mysql_bigint_unsigned_not_float() {
 
 #[test]
 fn test_mysql_bigint_unsigned_not_float_text() {
-    let _ = env_logger::builder().is_test(true).try_init();
-    let dburl = test_db::mysql_url();
-
-    let queries = [CXQuery::naked(
+    let result = run_mysql_query(
         "SELECT test_longlong_unsigned FROM test_types WHERE test_longlong_unsigned IS NOT NULL ORDER BY test_longlong_unsigned",
-    )];
-
-    let builder = MySQLSource::<TextProtocol>::new(&dburl, 1).unwrap();
-    let mut destination = ArrowDestination::new();
-    let dispatcher = Dispatcher::<_, _, MySQLArrowTransport<TextProtocol>>::new(
-        builder,
-        &mut destination,
-        &queries,
-        None,
+        false,
     );
-    dispatcher.run().unwrap();
-
-    let result = destination.arrow().unwrap();
-    assert!(result.len() == 1);
+    assert_eq!(result.len(), 1);
 
     let col = result[0]
         .column(0)
@@ -476,6 +423,58 @@ fn assert_str_collation_schema(result: &[RecordBatch]) {
             col,
             dt
         );
+    }
+}
+
+/// Run a single naked query through the Arrow transport using either the
+/// binary or text protocol.
+fn run_mysql_query(query: &str, binary: bool) -> Vec<RecordBatch> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let dburl = test_db::mysql_url();
+    let queries = [CXQuery::naked(query)];
+    let mut destination = ArrowDestination::new();
+
+    if binary {
+        let builder = MySQLSource::<BinaryProtocol>::new(&dburl, 1).unwrap();
+        Dispatcher::<_, _, MySQLArrowTransport<BinaryProtocol>>::new(
+            builder,
+            &mut destination,
+            &queries,
+            None,
+        )
+        .run()
+        .unwrap();
+    } else {
+        let builder = MySQLSource::<TextProtocol>::new(&dburl, 1).unwrap();
+        Dispatcher::<_, _, MySQLArrowTransport<TextProtocol>>::new(
+            builder,
+            &mut destination,
+            &queries,
+            None,
+        )
+        .run()
+        .unwrap();
+    }
+
+    destination.arrow().unwrap()
+}
+
+#[test]
+fn test_mysql_year() {
+    // YEAR is mapped to Int16. The value 2155 exceeds i8::MAX (127), so this
+    // test immediately catches any regression that narrows YEAR to Int8.
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_year FROM test_types WHERE test_year IS NOT NULL ORDER BY test_year",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int16Array>()
+            .unwrap()
+            .eq(&Int16Array::from(vec![1901i16, 2155])));
     }
 }
 
@@ -532,4 +531,170 @@ fn test_mysql_string_collation_types_text() {
     assert_eq!(result.len(), 1);
 
     assert_str_collation_schema(&result);
+}
+
+#[test]
+fn test_mysql_tiny_unsigned() {
+    // TINYINT UNSIGNED -> UInt8. 255 = u8::MAX, so any accidental narrowing to
+    // i8 or signed conversion makes this test fail.
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_tiny_unsigned FROM test_types \
+             WHERE test_tiny_unsigned IS NOT NULL ORDER BY test_tiny_unsigned",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .unwrap()
+            .eq(&UInt8Array::from(vec![0u8, 255])));
+    }
+}
+
+#[test]
+fn test_mysql_float() {
+    // FLOAT -> Float32. Compare with f32 literals so both sides are parsed at
+    // the same single precision.
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_float FROM test_types WHERE test_float IS NOT NULL ORDER BY test_float",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap()
+            .eq(&Float32Array::from(vec![-1.1E-38f32, 3.4E38f32])));
+    }
+}
+
+#[test]
+fn test_mysql_short() {
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_short FROM test_types WHERE test_short IS NOT NULL ORDER BY test_short",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int16Array>()
+            .unwrap()
+            .eq(&Int16Array::from(vec![-32768i16, 32767])));
+    }
+}
+
+#[test]
+fn test_mysql_int24() {
+    // MEDIUMINT has no i24 representation, so it is mapped to Int32.
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_int24 FROM test_types WHERE test_int24 IS NOT NULL ORDER BY test_int24",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .eq(&Int32Array::from(vec![-8388608i32, 8388607])));
+    }
+}
+
+#[test]
+fn test_mysql_long() {
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_long FROM test_types WHERE test_long IS NOT NULL ORDER BY test_long",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .eq(&Int32Array::from(vec![-2147483648i32, 2147483647])));
+    }
+}
+
+#[test]
+fn test_mysql_longlong() {
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_longlong FROM test_types \
+             WHERE test_longlong IS NOT NULL ORDER BY test_longlong",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .eq(&Int64Array::from(vec![
+                -9223372036854775808i64,
+                9223372036854775807,
+            ])));
+    }
+}
+
+#[test]
+fn test_mysql_short_unsigned() {
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_short_unsigned FROM test_types \
+             WHERE test_short_unsigned IS NOT NULL ORDER BY test_short_unsigned",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .unwrap()
+            .eq(&UInt16Array::from(vec![0u16, 65535])));
+    }
+}
+
+#[test]
+fn test_mysql_int24_unsigned() {
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_int24_unsigned FROM test_types \
+             WHERE test_int24_unsigned IS NOT NULL ORDER BY test_int24_unsigned",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap()
+            .eq(&UInt32Array::from(vec![0u32, 16777215])));
+    }
+}
+
+#[test]
+fn test_mysql_long_unsigned() {
+    for binary in [true, false] {
+        let result = run_mysql_query(
+            "SELECT test_long_unsigned FROM test_types \
+             WHERE test_long_unsigned IS NOT NULL ORDER BY test_long_unsigned",
+            binary,
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap()
+            .eq(&UInt32Array::from(vec![0u32, 4294967295])));
+    }
 }


### PR DESCRIPTION
## Summary

MySQL's Arrow transports widen several column types more than necessary. This PR maps them to their narrowest faithful Arrow type, continuing the work started in #905 (which addressed only the `arrow` destination and stopped at an `Int16`/`UInt16` floor).

## What changed

**Type systems (`arrow` and `arrowstream` destinations)**

Added `Int8` / `UInt8` variants to `ArrowTypeSystem` and the matching `ArrowAssoc` impls (`Int8Builder` / `UInt8Builder`).

**`mysql_arrow` transport**

| MySQL | Before | After |
|-------|--------|-------|
| `FLOAT` | `Float64` | `Float32` |
| `TINYINT` | `Int16` | `Int8` |
| `TINYINT UNSIGNED` | `UInt16` | `UInt8` |

**`mysql_arrowstream` transport**

The streaming transport previously upcast almost every integer to `Int64` and mapped *unsigned* types to *signed* `Int64`. It now preserves width and signedness, matching the `arrow` destination:

| MySQL | Before | After |
|-------|--------|-------|
| `FLOAT` | `Float64` | `Float32` |
| `TINYINT` | `Int16` | `Int8` |
| `SMALLINT` | `Int64` | `Int16` |
| `MEDIUMINT` / `INT` | `Int64` | `Int32` |
| `TINYINT UNSIGNED` | `Int64` (signed!) | `UInt8` |
| `SMALLINT UNSIGNED` | `Int64` (signed!) | `UInt16` |
| `MEDIUMINT/INT UNSIGNED` | `Int64` (signed!) | `UInt32` |
| `YEAR` | `Int64` | `Int16` |

`BIGINT`/`BIGINT UNSIGNED` (`Int64`/`UInt64`) and the temporal, decimal, string and blob mappings are unchanged.

## Compatibility / behavior change

This changes the **output Arrow schema**: affected columns now have a narrower width, and (for the streaming transport) unsigned columns are now returned as unsigned types instead of signed `Int64`. No data is lost or truncated — every value fits in the narrower type, and `BIGINT UNSIGNED` remains `UInt64` (it is never demoted to `Float64`). Downstream consumers that relied on the previous, wider/signed schema may need to adjust.

## Relation to prior work

- #688 — "Int dtypes are unnecessarily big"
- #905 — preserved sizes for the `arrow` destination down to `Int16`

This PR lowers the floor to `Int8`/`UInt8`, removes the unnecessary `FLOAT -> Float64` promotion, and brings the `arrowstream` destination up to parity (it was not touched by #905).

## Testing

Regression tests were added to `connectorx/tests/test_mysql.rs` for both the binary and text protocols, covering `YEAR`, `FLOAT`, and the full set of signed/unsigned integer widths. Boundary values already present in the `test_types` seed are used (e.g. `YEAR = 2155`, which does not fit in `Int8`, and `TINYINT UNSIGNED = 255`, which does not fit in `Int8`), so the tests fail immediately on any accidental narrowing or sign error. No seed changes were required.

## Why there is no `arrow_stream` test

The integration test file `tests/test_mysql.rs` is compiled only under the `dst_arrow` feature; there is currently no `dst_arrowstream` integration test. The `arrow` and `arrowstream` destinations duplicate their entire surface (separate type systems, transports and `ArrowAssoc` impls), so a test written against one does not exercise the other.

Adding proper `arrow_stream` coverage cleanly would mean either duplicating the test file under a `dst_arrowstream` cfg, or — better — introducing a destination-parameterized test harness so both destinations run the same assertions. That is a separate refactor and out of scope here. (The `connectorx-python` `arrow_stream` tests are likewise currently limited to DECIMAL, so this is a pre-existing structural gap rather than a regression.)

The `arrowstream` mapping changes are identical in shape to the `arrow` ones and depend on the same type-system additions, so they are covered at the mapping level by the `arrow` tests; the only uncovered part is destination-specific wiring, which the harness above would address. Happy to follow up with that in a separate PR.