### PR TITLE
fix: Rust panic in arrow_stream is not propagate to python

### DIFF
--- a/connectorx/src/arrow_batch_iter.rs
+++ b/connectorx/src/arrow_batch_iter.rs
@@ -32,6 +32,7 @@ where
     dorder: DataOrder,
     src_schema: Vec<S::TypeSystem>,
     dst_schema: Vec<ArrowStreamTypeSystem>,
+    handle: Option<std::thread::JoinHandle<Result<(), TP::Error>>>,
     _phantom: PhantomData<TP>,
 }
 
@@ -61,6 +62,7 @@ where
             dorder,
             src_schema,
             dst_schema,
+            handle: None,
             _phantom: PhantomData,
         })
     }
@@ -72,7 +74,7 @@ where
         let dst_partitions = self.dst_parts.take().unwrap();
         let dorder = self.dorder;
 
-        std::thread::spawn(move || -> Result<(), TP::Error> {
+        self.handle = Some(std::thread::spawn(move || -> Result<(), TP::Error> {
             let schemas: Vec<_> = src_schema
                 .iter()
                 .zip_eq(&dst_schema)
@@ -132,7 +134,7 @@ where
             debug!("Writing finished");
 
             Ok(())
-        });
+        }));
     }
 }
 
@@ -149,7 +151,21 @@ where
     type Item = RecordBatch;
     /// NOTE: not thread safe
     fn next(&mut self) -> Option<Self::Item> {
-        self.dst.record_batch().ok().flatten()
+        match self.dst.record_batch() {
+            Ok(Some(rb)) => Some(rb),
+            Ok(None) | Err(_) => {
+                // On stream end we must join the producer;
+                // a detached handle would swallow producer panics
+                if let Some(handle) = self.handle.take() {
+                    match handle.join() {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => panic!("cx writer failed: {:?}", e),
+                        Err(payload) => std::panic::resume_unwind(payload),
+                    }
+                }
+                None
+            }
+        }
     }
 }
 

--- a/connectorx/tests/test_arrow_stream.rs
+++ b/connectorx/tests/test_arrow_stream.rs
@@ -1,0 +1,64 @@
+use connectorx::arrow_batch_iter::ArrowBatchIter;
+use connectorx::destinations::arrowstream::ArrowDestinationError;
+use connectorx::impl_transport;
+use connectorx::prelude::*;
+use connectorx::sources::dummy::DummyTypeSystem;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PanicArrowStreamTransportError {
+    #[error(transparent)]
+    Destination(#[from] ArrowDestinationError),
+    #[error(transparent)]
+    ConnectorX(#[from] ConnectorXError),
+}
+
+pub struct PanicArrowStreamTransport;
+
+impl_transport!(
+    name = PanicArrowStreamTransport,
+    error = PanicArrowStreamTransportError,
+    systems = DummyTypeSystem => ArrowStreamTypeSystem,
+    route = DummySource => ArrowStreamDestination,
+    mappings = {
+        { I64[i64] => Int64[i64] | conversion none }
+    }
+);
+
+impl TypeConversion<i64, i64> for PanicArrowStreamTransport {
+    fn convert(val: i64) -> i64 {
+        if val == 3 {
+            panic!("intentional panic in stream producer");
+        }
+        val
+    }
+}
+
+impl TypeConversion<Option<i64>, Option<i64>> for PanicArrowStreamTransport {
+    fn convert(val: Option<i64>) -> Option<i64> {
+        val.map(|v| <Self as TypeConversion<i64, i64>>::convert(v))
+    }
+}
+
+#[test]
+fn producer_panic_propagates() {
+    let schema = [DummyTypeSystem::I64(false)];
+    let queries = [CXQuery::naked("10,1")];
+    let dst = ArrowStreamDestination::new_with_batch_size(2);
+    let mut iter = ArrowBatchIter::<_, PanicArrowStreamTransport>::new(
+        DummySource::new(&["a"], &schema),
+        dst,
+        None,
+        &queries,
+    )
+    .unwrap();
+    iter.prepare();
+
+    let first = iter.next().unwrap();
+    assert_eq!(first.num_rows(), 2);
+
+    // Two panic messages are printed during this test, both expected:
+    // 1. the producer thread panics intentionally, and
+    // 2. resume_unwind re-raises it on the consumer thread.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| iter.next()));
+    assert!(result.is_err(), "producer panic must propagate to consumer");
+}


### PR DESCRIPTION
## Summary

This fixes #913. When using return_type="arrow_stream", a Rust panic in the producer thread is not propagated to Python: no exception is raised, the process exits successfully, and the panic is only printed to stderr. The stream silently returns a truncated (often empty) result, which is particularly dangerous for data pipelines that then ingest incomplete data. The non-streaming arrow path does not have this problem because it already propagates the panic as a PanicException.

## Root cause

ArrowBatchIter::run() spawns the producer thread with std::thread::spawn(...) but does not keep the returned JoinHandle, so the thread is detached and its termination is never observed. When a partition panics, rayon re-raises the panic on that detached thread and the default hook prints "thread '<unnamed>' panicked at ...", but nothing ever reaches the consumer. In addition, next() used record_batch().ok().flatten(), which discards any error and maps it to None, making an early channel close indistinguishable from a normal end-of-stream.

## Fix

Store the JoinHandle on the iterator and join it when the stream reaches its end. If the producer panicked, re-raise the panic on the consumer thread (the thread calling into Python) with std::panic::resume_unwind, so PyO3 converts it into a PanicException at the __next__ boundary. If the producer returned a transport error, fail loudly as well. This makes arrow_stream consistent with the arrow path.

## Why the fix is value-agnostic

The silent path is fed by several unrelated panic sources: the nanosecond overflow on out-of-range datetimes reported in #913 (separately mitigated by the microsecond-precision change), zero dates such as 0000-00-00 from MySQL (#476, #268), and unsupported types (#547, #677). Because the fix surfaces the failure at the join boundary rather than handling specific values, every producer-side panic is propagated regardless of its cause.

## Scope and follow-up

This PR fixes propagation only. A transport error that is modeled as a Result is currently surfaced through panic! (and therefore as a PanicException) because Iterator::next can only return Option. Surfacing such errors as typed Python exceptions, matching the arrow path exactly, would require changing the RecordBatchIterator::next_batch signature to return a Result and deciding on a core error type. Because that changes the exception contract that downstream pipelines depend on, it is intentionally left out of this PR and proposed as a follow-up.

## Testing

Added a test using a dummy transport that panics in the middle of the stream on a specific value, and asserts via catch_unwind that the panic now propagates to the consumer instead of being silently swallowed.