### PR TITLE
Add support for mysql SSL mode

### DIFF
--- a/connectorx-python/connectorx/tests/test_mysql.py
+++ b/connectorx-python/connectorx/tests/test_mysql.py
@@ -1,10 +1,23 @@
+import os
+
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 
 from .. import read_sql, ConnectionUrl
 
 # mysql_url fixture is now defined in conftest.py
 # It uses testcontainers if available, otherwise the MYSQL_URL environment variable
+
+
+@pytest.fixture(scope="module")
+def mysql_url_tls() -> str:
+    return os.environ["MYSQL_URL_TLS"]
+
+
+@pytest.fixture(scope="module")
+def mysql_rootcert() -> str:
+    return os.environ["MYSQL_ROOTCERT"]
 
 
 def test_mysql_without_partition(mysql_url: str) -> None:
@@ -653,3 +666,62 @@ def test_mysql_decimal_pandas_unchanged(mysql_url: str) -> None:
     assert df['test_decimal'][0] == 1.0
     assert df['test_decimal'][1] == 2.0
     assert pd.isna(df['test_decimal'][2])
+
+
+def _expected_test_table() -> pd.DataFrame:
+    return pd.DataFrame(
+        index=range(6),
+        data={
+            "test_int": pd.Series([1, 2, 3, 4, 5, 6], dtype="Int64"),
+            "test_float": pd.Series([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype="float64"),
+            "test_enum": pd.Series(
+                ["odd", "even", "odd", "even", "odd", "even"], dtype="object"
+            ),
+            "test_null": pd.Series([None, None, None, None, None, None], dtype="Int64"),
+        },
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MYSQL_URL_TLS"),
+    reason="Do not test MySQL TLS unless `MYSQL_URL_TLS` is set",
+)
+def test_mysql_tls_required(mysql_url_tls: str) -> None:
+    df = read_sql(f"{mysql_url_tls}?ssl-mode=REQUIRED", "SELECT * FROM test_table")
+    df.sort_values(by="test_int", inplace=True, ignore_index=True)
+    assert_frame_equal(df, _expected_test_table(), check_names=True)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MYSQL_URL_TLS"),
+    reason="Do not test MySQL TLS unless `MYSQL_URL_TLS` is set",
+)
+def test_mysql_tls_verify_ca(mysql_url_tls: str, mysql_rootcert: str) -> None:
+    df = read_sql(
+        f"{mysql_url_tls}?ssl-mode=VERIFY_CA&ssl-ca={mysql_rootcert}",
+        "SELECT * FROM test_table",
+    )
+    df.sort_values(by="test_int", inplace=True, ignore_index=True)
+    assert_frame_equal(df, _expected_test_table(), check_names=True)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MYSQL_URL_TLS"),
+    reason="Do not test MySQL TLS unless `MYSQL_URL_TLS` is set",
+)
+def test_mysql_tls_disabled(mysql_url_tls: str) -> None:
+    df = read_sql(f"{mysql_url_tls}?ssl-mode=DISABLED", "SELECT * FROM test_table")
+    df.sort_values(by="test_int", inplace=True, ignore_index=True)
+    assert_frame_equal(df, _expected_test_table(), check_names=True)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MYSQL_URL_TLS"),
+    reason="Do not test MySQL TLS unless `MYSQL_URL_TLS` is set",
+)
+def test_mysql_tls_verify_ca_rejects_untrusted_ca(mysql_url_tls: str) -> None:
+    with pytest.raises(RuntimeError):
+        read_sql(
+            f"{mysql_url_tls}?ssl-mode=VERIFY_CA&ssl-ca=fake.cert",
+            "SELECT * FROM test_table",
+        )

--- a/connectorx-python/connectorx/tests/test_mysql.py
+++ b/connectorx-python/connectorx/tests/test_mysql.py
@@ -693,8 +693,8 @@ def test_mysql_tls_required(mysql_url_tls: str) -> None:
 
 
 @pytest.mark.skipif(
-    not os.environ.get("MYSQL_URL_TLS"),
-    reason="Do not test MySQL TLS unless `MYSQL_URL_TLS` is set",
+    not (os.environ.get("MYSQL_URL_TLS") and os.environ.get("MYSQL_ROOTCERT")),
+    reason="Do not test MySQL TLS CA verification unless `MYSQL_URL_TLS` and `MYSQL_ROOTCERT` are set",
 )
 def test_mysql_tls_verify_ca(mysql_url_tls: str, mysql_rootcert: str) -> None:
     df = read_sql(

--- a/connectorx/src/partition.rs
+++ b/connectorx/src/partition.rs
@@ -9,7 +9,7 @@ use crate::sources::clickhouse::{ClickHouseSource, ClickHouseSourceError};
 #[cfg(feature = "src_mssql")]
 use crate::sources::mssql::{mssql_config, FloatN, IntN, MsSQLTypeSystem};
 #[cfg(feature = "src_mysql")]
-use crate::sources::mysql::{MySQLSourceError, MySQLTypeSystem};
+use crate::sources::mysql::{build_opts, MySQLTypeSystem};
 #[cfg(feature = "src_oracle")]
 use crate::sources::oracle::{OracleDialect, OracleSource};
 #[cfg(feature = "src_postgres")]
@@ -24,7 +24,7 @@ use fehler::{throw, throws};
 #[cfg(feature = "src_bigquery")]
 use gcp_bigquery_client;
 #[cfg(feature = "src_mysql")]
-use r2d2_mysql::mysql::{prelude::Queryable, Opts, Pool, Row};
+use r2d2_mysql::mysql::{prelude::Queryable, Pool, Row};
 #[cfg(feature = "src_sqlite")]
 use rusqlite::{types::Type, Connection};
 #[cfg(feature = "src_postgres")]
@@ -275,7 +275,7 @@ fn sqlite_get_partition_range(conn: &Url, query: &str, col: &str) -> (i64, i64) 
 #[cfg(feature = "src_mysql")]
 #[throws(ConnectorXOutError)]
 fn mysql_get_partition_range(conn: &Url, query: &str, col: &str) -> (i64, i64) {
-    let pool = Pool::new(Opts::from_url(conn.as_str()).map_err(MySQLSourceError::MySQLUrlError)?)?;
+    let pool = Pool::new(build_opts(conn.as_str())?)?;
     let mut conn = pool.get_conn()?;
     let range_query = get_partition_range_query(query, col, &MySqlDialect {})?;
     let row: Row = conn

--- a/connectorx/src/sources/mysql/connection.rs
+++ b/connectorx/src/sources/mysql/connection.rs
@@ -1,0 +1,151 @@
+use super::errors::MySQLSourceError;
+use r2d2_mysql::mysql::{Opts, OptsBuilder, SslOpts};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use url::Url;
+
+/// URL query parameters consumed here and stripped before the URL is handed to the
+/// `mysql` crate, which rejects any parameter it does not recognize.
+const SSL_PARAMS: &[&str] = &["ssl-mode", "sslmode", "ssl-ca"];
+
+/// Build the connection options for a MySQL URL, translating the `ssl-mode` (and
+/// `ssl-ca`) query parameters into a [`SslOpts`].
+///
+/// The `mysql` crate configures TLS programmatically via [`OptsBuilder::ssl_opts`] and
+/// errors on unknown URL parameters, so the SSL parameters are parsed and removed here
+/// rather than passed through to [`Opts::from_url`].
+pub fn build_opts(conn: &str) -> Result<OptsBuilder, MySQLSourceError> {
+    let url = Url::parse(conn)?;
+
+    let params: HashMap<String, String> = url
+        .query_pairs()
+        .map(|(k, v)| (k.to_ascii_lowercase(), v.into_owned()))
+        .collect();
+    let ssl_opts = ssl_opts_from_params(&params)?;
+
+    let opts = Opts::from_url(strip_ssl_params(&url).as_str())?;
+    Ok(OptsBuilder::from_opts(opts).ssl_opts(ssl_opts))
+}
+
+/// Translate a MySQL `ssl-mode` value into [`SslOpts`], returning `None` when TLS is not
+/// requested (no `ssl-mode`, or `ssl-mode=DISABLED`) so that behavior is unchanged for
+/// connection strings without SSL parameters.
+///
+/// `PREFERRED` is treated as `REQUIRED` (encrypt without verification): the `mysql` crate
+/// has no opportunistic mode that falls back to plaintext when the server lacks TLS.
+fn ssl_opts_from_params(
+    params: &HashMap<String, String>,
+) -> Result<Option<SslOpts>, MySQLSourceError> {
+    let mode = match params.get("ssl-mode").or_else(|| params.get("sslmode")) {
+        Some(mode) => mode,
+        None => return Ok(None),
+    };
+
+    let (accept_invalid_certs, skip_domain_validation) =
+        match mode.trim().to_ascii_uppercase().replace('-', "_").as_str() {
+            "DISABLED" => return Ok(None),
+            "PREFERRED" | "REQUIRED" => (true, true),
+            "VERIFY_CA" => (false, true),
+            "VERIFY_IDENTITY" => (false, false),
+            _ => return Err(MySQLSourceError::InvalidSslMode(mode.clone())),
+        };
+
+    let ssl_opts = SslOpts::default()
+        .with_danger_accept_invalid_certs(accept_invalid_certs)
+        .with_danger_skip_domain_validation(skip_domain_validation)
+        .with_root_cert_path(params.get("ssl-ca").map(PathBuf::from));
+    Ok(Some(ssl_opts))
+}
+
+fn strip_ssl_params(url: &Url) -> Url {
+    let kept: Vec<(String, String)> = url
+        .query_pairs()
+        .filter(|(k, _)| !SSL_PARAMS.contains(&k.to_ascii_lowercase().as_str()))
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+
+    let mut stripped = url.clone();
+    stripped.set_query(None);
+    for (k, v) in kept {
+        stripped.query_pairs_mut().append_pair(&k, &v);
+    }
+    stripped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ssl_opts(conn: &str) -> Option<SslOpts> {
+        let opts: Opts = build_opts(conn).unwrap().into();
+        opts.get_ssl_opts().cloned()
+    }
+
+    #[test]
+    fn no_ssl_mode_disables_tls() {
+        assert!(ssl_opts("mysql://user:pass@host:3306/db").is_none());
+        assert!(ssl_opts("mysql://user:pass@host:3306/db?ssl-mode=DISABLED").is_none());
+    }
+
+    #[test]
+    fn required_encrypts_without_verification() {
+        let opts = ssl_opts("mysql://user:pass@host:3306/db?ssl-mode=REQUIRED").unwrap();
+        assert!(opts.accept_invalid_certs());
+        assert!(opts.skip_domain_validation());
+        assert!(opts.root_cert_path().is_none());
+    }
+
+    #[test]
+    fn preferred_is_treated_as_required() {
+        assert_eq!(
+            ssl_opts("mysql://user:pass@host:3306/db?ssl-mode=PREFERRED"),
+            ssl_opts("mysql://user:pass@host:3306/db?ssl-mode=REQUIRED"),
+        );
+    }
+
+    #[test]
+    fn verify_ca_checks_chain_but_not_hostname() {
+        let opts = ssl_opts("mysql://user:pass@host:3306/db?ssl-mode=VERIFY_CA&ssl-ca=/tmp/ca.pem")
+            .unwrap();
+        assert!(!opts.accept_invalid_certs());
+        assert!(opts.skip_domain_validation());
+        assert_eq!(
+            opts.root_cert_path(),
+            Some(std::path::Path::new("/tmp/ca.pem"))
+        );
+    }
+
+    #[test]
+    fn verify_identity_checks_chain_and_hostname() {
+        let opts = ssl_opts("mysql://user:pass@host:3306/db?ssl-mode=VERIFY_IDENTITY").unwrap();
+        assert!(!opts.accept_invalid_certs());
+        assert!(!opts.skip_domain_validation());
+    }
+
+    #[test]
+    fn ssl_mode_is_case_insensitive_and_accepts_sslmode_alias() {
+        assert!(ssl_opts("mysql://user:pass@host:3306/db?ssl-mode=required").is_some());
+        assert!(ssl_opts("mysql://user:pass@host:3306/db?sslmode=Required").is_some());
+    }
+
+    #[test]
+    fn invalid_ssl_mode_errors() {
+        assert!(matches!(
+            build_opts("mysql://user:pass@host:3306/db?ssl-mode=bogus"),
+            Err(MySQLSourceError::InvalidSslMode(_))
+        ));
+    }
+
+    #[test]
+    fn ssl_params_are_stripped_so_the_url_parses_and_other_params_survive() {
+        // `ssl-ca` is not a parameter the mysql crate recognizes, so build_opts must
+        // strip it (otherwise the URL is rejected) while leaving non-SSL params intact.
+        let opts: Opts = build_opts(
+            "mysql://user:pass@host:3306/db?ssl-mode=REQUIRED&ssl-ca=/tmp/ca.pem&prefer_socket=false",
+        )
+        .unwrap()
+        .into();
+        assert!(opts.get_ssl_opts().is_some());
+        assert!(!opts.get_prefer_socket());
+    }
+}

--- a/connectorx/src/sources/mysql/errors.rs
+++ b/connectorx/src/sources/mysql/errors.rs
@@ -14,6 +14,12 @@ pub enum MySQLSourceError {
     #[error(transparent)]
     MySQLPoolError(#[from] r2d2::Error),
 
+    #[error(transparent)]
+    UrlParseError(#[from] url::ParseError),
+
+    #[error("unsupported ssl-mode value: {0}")]
+    InvalidSslMode(String),
+
     /// Any other errors that are too trivial to be put here explicitly.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/connectorx/src/sources/mysql/mod.rs
+++ b/connectorx/src/sources/mysql/mod.rs
@@ -1,8 +1,10 @@
 //! Source implementation for MySQL database.
 
+mod connection;
 mod errors;
 mod typesystem;
 
+pub use self::connection::build_opts;
 pub use self::errors::MySQLSourceError;
 use crate::constants::DB_BUFFER_SIZE;
 use crate::{
@@ -23,7 +25,7 @@ use r2d2_mysql::{
             UTF8_GENERAL_CI,
         },
         prelude::Queryable,
-        Binary, Opts, OptsBuilder, QueryResult, Row, Text,
+        Binary, QueryResult, Row, Text,
     },
     MySqlConnectionManager,
 };
@@ -57,7 +59,7 @@ pub struct MySQLSource<P> {
 impl<P> MySQLSource<P> {
     #[throws(MySQLSourceError)]
     pub fn new(conn: &str, nconn: usize) -> Self {
-        let manager = MySqlConnectionManager::new(OptsBuilder::from_opts(Opts::from_url(conn)?));
+        let manager = MySqlConnectionManager::new(build_opts(conn)?);
         let pool = r2d2::Pool::builder()
             .max_size(nconn as u32)
             .build(manager)?;

--- a/connectorx/src/sources/mysql/mod.rs
+++ b/connectorx/src/sources/mysql/mod.rs
@@ -1,8 +1,10 @@
 //! Source implementation for MySQL database.
 
+mod connection;
 mod errors;
 mod typesystem;
 
+pub use self::connection::build_opts;
 pub use self::errors::MySQLSourceError;
 use crate::constants::DB_BUFFER_SIZE;
 use crate::{
@@ -17,7 +19,7 @@ use fehler::{throw, throws};
 use log::{debug, warn};
 use r2d2::{Pool, PooledConnection};
 use r2d2_mysql::{
-    mysql::{prelude::Queryable, Binary, Opts, OptsBuilder, QueryResult, Row, Text},
+    mysql::{prelude::Queryable, Binary, QueryResult, Row, Text},
     MySqlConnectionManager,
 };
 use rust_decimal::Decimal;
@@ -50,7 +52,7 @@ pub struct MySQLSource<P> {
 impl<P> MySQLSource<P> {
     #[throws(MySQLSourceError)]
     pub fn new(conn: &str, nconn: usize) -> Self {
-        let manager = MySqlConnectionManager::new(OptsBuilder::from_opts(Opts::from_url(conn)?));
+        let manager = MySqlConnectionManager::new(build_opts(conn)?);
         let pool = r2d2::Pool::builder()
             .max_size(nconn as u32)
             .build(manager)?;

--- a/docs/databases/mysql.md
+++ b/docs/databases/mysql.md
@@ -12,6 +12,29 @@ query = 'SELECT * FROM table'                                   # query string
 cx.read_sql(conn, query)                                        # read data from MySQL
 ```
 
+## MySQL SSL/TLS
+
+Add an `ssl-mode` parameter to the connection URI to negotiate a TLS connection, e.g.
+`mysql://username:password@server:port/database?ssl-mode=REQUIRED`. Values are case-insensitive and
+follow MySQL's semantics:
+
+| `ssl-mode`        | Behavior                                                                 |
+|:-----------------:|:-------------------------------------------------------------------------|
+| `DISABLED`        | No TLS. Same as omitting `ssl-mode` (the default).                       |
+| `PREFERRED`       | Encrypt without verifying the server certificate. See the note below.    |
+| `REQUIRED`        | Encrypt without verifying the server certificate.                        |
+| `VERIFY_CA`       | Encrypt and verify the server certificate against a CA.                  |
+| `VERIFY_IDENTITY` | Encrypt and verify both the CA and the server hostname.                  |
+
+For `VERIFY_CA` and `VERIFY_IDENTITY`, supply the CA certificate with `ssl-ca` (a path to a PEM or DER
+file), e.g. `?ssl-mode=VERIFY_CA&ssl-ca=/path/to/ca.pem`. When `ssl-ca` is omitted, verification uses
+the system trust store.
+
+> **Note:** `PREFERRED` is treated the same as `REQUIRED` (the connection is always encrypted); unlike
+> the MySQL client, it does not fall back to an unencrypted connection when the server lacks TLS.
+
+> **Note:** Client-certificate (mutual TLS) authentication is not yet supported.
+
 ## MySQL-Pandas Type Mapping
 | MySQL Type      |      Pandas Type            |  Comment                           |
 |:---------------:|:---------------------------:|:----------------------------------:|


### PR DESCRIPTION
Closes https://github.com/sfu-db/connector-x/issues/347

Currently connector-x does not support server-side SSL certification `?ssl-mode=REQUIRED`, and it is thus not possible to connect to a server that forces TLS. This functionality is available in the `native-tls` backend that connector-x's MySQL stack already uses, so this PR mostly just adds some parsing and argument forwarding.

I punted on full client-certificate mutual TLS, because that would be a deeper change and it wasn't requested in the linked issue. I also don't need it for my personal use-case, so there you go.

AI disclosure: This PR was written with the assistance of Claude Code, with me in the loop the whole time. I have reviewed the code manually and checked it against the contributing documentation I could find. 