### PR TITLE
fix(sql): avoid query execution for schema discovery (LIMIT 0 + SQLite stmt.columns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This allows it to make full use of the CPU by becoming cache and branch predicto
 
 ## How does ConnectorX download the data?
 
-Upon receiving the query, e.g. `SELECT * FROM lineitem`, ConnectorX will first get the schema of the result set. Depending on the data source, this process may envolve issuing a `LIMIT 1` query `SELECT * FROM lineitem LIMIT 1`.
+Upon receiving the query, e.g. `SELECT * FROM lineitem`, ConnectorX will first get the schema of the result set. Depending on the data source, this process may involve issuing a `LIMIT 0` query `SELECT * FROM lineitem LIMIT 0`.
 
 Then, if `partition_on` is specified, ConnectorX will issue `SELECT MIN($partition_on), MAX($partition_on) FROM (SELECT * FROM lineitem)` to know the range of the partition column.
 After that, the original query is split into partitions based on the min/max information, e.g. `SELECT * FROM (SELECT * FROM lineitem) WHERE $partition_on > 0 AND $partition_on < 10000`.

--- a/connectorx-python/connectorx/tests/test_sqlite.py
+++ b/connectorx-python/connectorx/tests/test_sqlite.py
@@ -309,14 +309,14 @@ def test_empty_result(sqlite_db: str) -> None:
     df = read_sql(sqlite_db, query)
     expected = pd.DataFrame(
         data={
-            "test_int": pd.Series([], dtype="object"),
-            "test_nullint": pd.Series([], dtype="object"),
+            "test_int": pd.Series([], dtype="Int64"),
+            "test_nullint": pd.Series([], dtype="Int64"),
             "test_str": pd.Series([], dtype="object"),
-            "test_float": pd.Series([], dtype="object"),
-            "test_bool": pd.Series([], dtype="object"),
-            "test_date": pd.Series([], dtype="object"),
+            "test_float": pd.Series([], dtype="float64"),
+            "test_bool": pd.Series([], dtype="boolean"),
+            "test_date": pd.Series([], dtype="datetime64[us]"),
             "test_time": pd.Series([], dtype="object"),
-            "test_datetime": pd.Series([], dtype="object"),
+            "test_datetime": pd.Series([], dtype="datetime64[us]"),
         }
     )
     assert_frame_equal(df, expected, check_names=True)
@@ -327,14 +327,14 @@ def test_empty_result_on_partition(sqlite_db: str) -> None:
     df = read_sql(sqlite_db, query, partition_on="test_int", partition_num=3)
     expected = pd.DataFrame(
         data={
-            "test_int": pd.Series([], dtype="object"),
-            "test_nullint": pd.Series([], dtype="object"),
+            "test_int": pd.Series([], dtype="Int64"),
+            "test_nullint": pd.Series([], dtype="Int64"),
             "test_str": pd.Series([], dtype="object"),
-            "test_float": pd.Series([], dtype="object"),
-            "test_bool": pd.Series([], dtype="object"),
-            "test_date": pd.Series([], dtype="object"),
+            "test_float": pd.Series([], dtype="float64"),
+            "test_bool": pd.Series([], dtype="boolean"),
+            "test_date": pd.Series([], dtype="datetime64[us]"),
             "test_time": pd.Series([], dtype="object"),
-            "test_datetime": pd.Series([], dtype="object"),
+            "test_datetime": pd.Series([], dtype="datetime64[us]"),
         }
     )
     assert_frame_equal(df, expected, check_names=True)

--- a/connectorx/src/lib.rs
+++ b/connectorx/src/lib.rs
@@ -49,7 +49,7 @@
 //! ```
 //! ## How does ConnectorX download the data?
 //!
-//! Upon receiving the query, e.g. SELECT * FROM lineitem, ConnectorX will first issue a LIMIT 1 query SELECT * FROM lineitem LIMIT 1 to get the schema of the result set.
+//! Upon receiving the query, e.g. SELECT * FROM lineitem, ConnectorX will first issue a LIMIT 0 query SELECT * FROM lineitem LIMIT 0 to get the schema of the result set.
 //!
 //! Then, if partition_on is specified, ConnectorX will issue `SELECT MIN($partition_on), MAX($partition_on) FROM (SELECT * FROM lineitem)` to know the range of the partition column.
 //! After that, the original query is split into partitions based on the min/max information, e.g. `SELECT * FROM (SELECT * FROM lineitem) WHERE $partition_on > 0 AND $partition_on < 10000`.

--- a/connectorx/src/sources/bigquery/mod.rs
+++ b/connectorx/src/sources/bigquery/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     data_order::DataOrder,
     errors::ConnectorXError,
     sources::{PartitionParser, Produce, Source, SourcePartition},
-    sql::{count_query, limit1_query, CXQuery},
+    sql::{count_query, limit0_query, CXQuery},
 };
 use anyhow::anyhow;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
@@ -113,7 +113,7 @@ where
         assert!(!self.queries.is_empty());
         let job = self.client.job();
         for (_, query) in self.queries.iter().enumerate() {
-            let l1query = limit1_query(query, &BigQueryDialect {})?;
+            let l1query = limit0_query(query, &BigQueryDialect {})?;
             let rs = self.rt.block_on(job.query(
                 self.project_id.as_str(),
                 QueryRequest::new(l1query.as_str()),

--- a/connectorx/src/sources/clickhouse/mod.rs
+++ b/connectorx/src/sources/clickhouse/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     sources::{
         clickhouse::typesystem::DataType, PartitionParser, Produce, Source, SourcePartition,
     },
-    sql::{count_query, limit1_query, CXQuery},
+    sql::{count_query, limit0_query, CXQuery},
 };
 use anyhow::anyhow;
 use chrono::{DateTime, Duration, NaiveDate, NaiveTime, Utc};
@@ -116,7 +116,7 @@ where
         assert!(!self.queries.is_empty());
 
         let first_query = &self.queries[0];
-        let l1query = limit1_query(first_query, &ClickHouseDialect {})?;
+        let l1query = limit0_query(first_query, &ClickHouseDialect {})?;
 
         let describe_query = format!("DESCRIBE ({})", l1query.as_str());
 

--- a/connectorx/src/sources/mysql/mod.rs
+++ b/connectorx/src/sources/mysql/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     data_order::DataOrder,
     errors::ConnectorXError,
     sources::{PartitionParser, Produce, Source, SourcePartition},
-    sql::{count_query, limit1_query, CXQuery},
+    sql::{count_query, limit0_query, CXQuery},
 };
 use anyhow::anyhow;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -130,7 +130,7 @@ where
                 for (i, query) in self.queries.iter().enumerate() {
                     // assuming all the partition queries yield same schema
                     match conn
-                        .query_first::<Row, _>(limit1_query(query, &MySqlDialect {})?.as_str())
+                        .query_first::<Row, _>(limit0_query(query, &MySqlDialect {})?.as_str())
                     {
                         Ok(Some(row)) => {
                             let (names, types) = row

--- a/connectorx/src/sources/oracle/mod.rs
+++ b/connectorx/src/sources/oracle/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     data_order::DataOrder,
     errors::ConnectorXError,
     sources::{PartitionParser, Produce, Source, SourcePartition},
-    sql::{count_query, limit1_query_oracle, CXQuery},
+    sql::{count_query, limit0_query_oracle, CXQuery},
     utils::DummyBox,
 };
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
@@ -144,7 +144,7 @@ where
             // without rownum = 1, derived type might be wrong
             // example: select avg(test_int), test_char from test_table group by test_char
             // -> (NumInt, Char) instead of (NumtFloat, Char)
-            match conn.query(limit1_query_oracle(query)?.as_str(), &[]) {
+            match conn.query(limit0_query_oracle(query)?.as_str(), &[]) {
                 Ok(rows) => {
                     let (names, types) = rows
                         .column_info()

--- a/connectorx/src/sources/sqlite/mod.rs
+++ b/connectorx/src/sources/sqlite/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     data_order::DataOrder,
     errors::ConnectorXError,
     sources::{PartitionParser, Produce, Source, SourcePartition},
-    sql::{count_query, limit0_query, CXQuery},
+    sql::{count_query, limit1_query, CXQuery},
     utils::DummyBox,
 };
 use anyhow::anyhow;
@@ -81,40 +81,55 @@ where
     fn fetch_metadata(&mut self) {
         assert!(!self.queries.is_empty());
         let conn = self.pool.get()?;
-        let mut names = vec![];
-        let mut types = vec![];
+
+        // Use prepare + stmt.columns() to get schema without executing the query.
+        // This gives us column names and decl_type from the DDL, which is sufficient
+        // for most cases and avoids running the query at all (issue #768).
+        let stmt = conn.prepare(self.queries[0].as_str())?;
+        let columns = stmt.columns();
+
+        let mut names: Vec<String> = Vec::with_capacity(columns.len());
+        let mut types: Vec<Option<SQLiteTypeSystem>> = Vec::with_capacity(columns.len());
+
+        for col in &columns {
+            names.push(col.name().to_string());
+            let decl_type = col.decl_type();
+            match SQLiteTypeSystem::try_from((decl_type, rusqlite::types::Type::Null)) {
+                Ok(t) => types.push(Some(t)),
+                Err(_) => types.push(None),
+            }
+        }
+
+        // If all types were resolved from decl_type, we're done
+        if !types.contains(&None) {
+            self.names = names;
+            self.schema = types.into_iter().map(|t| t.unwrap()).collect();
+            return;
+        }
+
+        // Some columns lack decl_type (computed expressions, aggregates, etc.).
+        // Fall back to executing with LIMIT 1 to infer types from actual values.
+        drop(columns);
+        drop(stmt);
+
         let mut num_empty = 0;
-
-        // assuming all the partition queries yield same schema
         for (i, query) in self.queries.iter().enumerate() {
-            let l1query = limit0_query(query, &SQLiteDialect {})?;
+            let l1query = limit1_query(query, &SQLiteDialect {})?;
 
-            let is_sucess = conn.query_row(l1query.as_str(), [], |row| {
+            let is_success = conn.query_row(l1query.as_str(), [], |row| {
                 for (j, col) in row.as_ref().columns().iter().enumerate() {
-                    if j >= names.len() {
-                        names.push(col.name().to_string());
-                    }
-                    if j >= types.len() {
-                        let vr = row.get_ref(j)?;
-                        match SQLiteTypeSystem::try_from((col.decl_type(), vr.data_type())) {
-                            Ok(t) => types.push(Some(t)),
-                            Err(_) => {
-                                types.push(None);
-                            }
-                        }
-                    } else if types[j].is_none() {
-                        // We didn't get the type in the previous round
+                    if types[j].is_none() {
                         let vr = row.get_ref(j)?;
                         if let Ok(t) = SQLiteTypeSystem::try_from((col.decl_type(), vr.data_type()))
                         {
-                            types[j] = Some(t)
+                            types[j] = Some(t);
                         }
                     }
                 }
                 Ok(())
             });
 
-            match is_sucess {
+            match is_success {
                 Ok(()) => {
                     if !types.contains(&None) {
                         self.names = names;
@@ -130,10 +145,9 @@ where
                 }
                 Err(e) => {
                     if let rusqlite::Error::QueryReturnedNoRows = e {
-                        num_empty += 1; // make sure when all partition results are empty, do not throw error
+                        num_empty += 1;
                     }
                     if i == self.queries.len() - 1 && num_empty < self.queries.len() {
-                        // tried the last query but still get an error
                         debug!("cannot get metadata for '{}': {}", query, e);
                         throw!(e)
                     }
@@ -141,16 +155,13 @@ where
             }
         }
 
-        // tried all queries but all get empty result set
-        let stmt = conn.prepare(self.queries[0].as_str())?;
-
-        self.names = stmt
-            .column_names()
+        // All partitions returned empty results - use decl_type where available,
+        // fall back to Text for columns without type info
+        self.names = names;
+        self.schema = types
             .into_iter()
-            .map(|s| s.to_string())
+            .map(|t| t.unwrap_or(SQLiteTypeSystem::Text(false)))
             .collect();
-        // set all columns as string (align with pandas)
-        self.schema = vec![SQLiteTypeSystem::Text(false); self.names.len()];
     }
 
     #[throws(SQLiteSourceError)]

--- a/connectorx/src/sources/sqlite/mod.rs
+++ b/connectorx/src/sources/sqlite/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     data_order::DataOrder,
     errors::ConnectorXError,
     sources::{PartitionParser, Produce, Source, SourcePartition},
-    sql::{count_query, limit1_query, CXQuery},
+    sql::{count_query, limit0_query, CXQuery},
     utils::DummyBox,
 };
 use anyhow::anyhow;
@@ -87,7 +87,7 @@ where
 
         // assuming all the partition queries yield same schema
         for (i, query) in self.queries.iter().enumerate() {
-            let l1query = limit1_query(query, &SQLiteDialect {})?;
+            let l1query = limit0_query(query, &SQLiteDialect {})?;
 
             let is_sucess = conn.query_row(l1query.as_str(), [], |row| {
                 for (j, col) in row.as_ref().columns().iter().enumerate() {

--- a/connectorx/src/sources/trino/mod.rs
+++ b/connectorx/src/sources/trino/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     data_order::DataOrder,
     errors::ConnectorXError,
     sources::Produce,
-    sql::{count_query, limit1_query, CXQuery},
+    sql::{count_query, limit0_query, CXQuery},
 };
 
 pub use self::{errors::TrinoSourceError, typesystem::TrinoTypeSystem};
@@ -221,7 +221,7 @@ where
         assert!(!self.queries.is_empty());
 
         let first_query = &self.queries[0];
-        let cxq = limit1_query(first_query, &GenericDialect {})?;
+        let cxq = limit0_query(first_query, &GenericDialect {})?;
 
         let dataset: DataSet<Row> = self
             .rt

--- a/connectorx/src/sql.rs
+++ b/connectorx/src/sql.rs
@@ -270,7 +270,7 @@ pub fn limit1_query<T: Dialect>(sql: &CXQuery<String>, dialect: &T) -> CXQuery<S
 
             match &mut ast[0] {
                 Statement::Query(q) => {
-                    q.limit = Some(Expr::Value(Value::Number("1".to_string(), false)));
+                    q.limit = Some(Expr::Value(Value::Number("0".to_string(), false)));
                 }
                 _ => throw!(ConnectorXError::SqlQueryNotSupported(sql.to_string())),
             };
@@ -279,11 +279,11 @@ pub fn limit1_query<T: Dialect>(sql: &CXQuery<String>, dialect: &T) -> CXQuery<S
         }
         Err(e) => {
             warn!("parser error: {:?}, manually compose query string", e);
-            format!("{} LIMIT 1", sql.as_str())
+            format!("{} LIMIT 0", sql.as_str())
         }
     };
 
-    debug!("Transformed limit 1 query: {}", sql);
+    debug!("Transformed limit 0 query: {}", sql);
     CXQuery::Wrapped(sql)
 }
 

--- a/connectorx/src/sql.rs
+++ b/connectorx/src/sql.rs
@@ -287,6 +287,37 @@ pub fn limit0_query<T: Dialect>(sql: &CXQuery<String>, dialect: &T) -> CXQuery<S
     CXQuery::Wrapped(sql)
 }
 
+/// Like limit0_query but with LIMIT 1. Used by SQLite where schema inference
+/// requires at least one row when decl_type is not available.
+#[throws(ConnectorXError)]
+pub fn limit1_query<T: Dialect>(sql: &CXQuery<String>, dialect: &T) -> CXQuery<String> {
+    trace!("Incoming query: {}", sql);
+
+    let sql = match Parser::parse_sql(dialect, sql.as_str()) {
+        Ok(mut ast) => {
+            if ast.len() != 1 {
+                throw!(ConnectorXError::SqlQueryNotSupported(sql.to_string()));
+            }
+
+            match &mut ast[0] {
+                Statement::Query(q) => {
+                    q.limit = Some(Expr::Value(Value::Number("1".to_string(), false)));
+                }
+                _ => throw!(ConnectorXError::SqlQueryNotSupported(sql.to_string())),
+            };
+
+            format!("{}", ast[0])
+        }
+        Err(e) => {
+            warn!("parser error: {:?}, manually compose query string", e);
+            format!("{} LIMIT 1", sql.as_str())
+        }
+    };
+
+    debug!("Transformed limit 1 query: {}", sql);
+    CXQuery::Wrapped(sql)
+}
+
 #[throws(ConnectorXError)]
 #[cfg(feature = "src_oracle")]
 pub fn limit0_query_oracle(sql: &CXQuery<String>) -> CXQuery<String> {

--- a/connectorx/src/sql.rs
+++ b/connectorx/src/sql.rs
@@ -259,7 +259,7 @@ pub fn count_query<T: Dialect>(sql: &CXQuery<String>, dialect: &T) -> CXQuery<St
 }
 
 #[throws(ConnectorXError)]
-pub fn limit1_query<T: Dialect>(sql: &CXQuery<String>, dialect: &T) -> CXQuery<String> {
+pub fn limit0_query<T: Dialect>(sql: &CXQuery<String>, dialect: &T) -> CXQuery<String> {
     trace!("Incoming query: {}", sql);
 
     let sql = match Parser::parse_sql(dialect, sql.as_str()) {
@@ -289,10 +289,10 @@ pub fn limit1_query<T: Dialect>(sql: &CXQuery<String>, dialect: &T) -> CXQuery<S
 
 #[throws(ConnectorXError)]
 #[cfg(feature = "src_oracle")]
-pub fn limit1_query_oracle(sql: &CXQuery<String>) -> CXQuery<String> {
+pub fn limit0_query_oracle(sql: &CXQuery<String>) -> CXQuery<String> {
     trace!("Incoming oracle query: {}", sql);
 
-    CXQuery::Wrapped(format!("SELECT * FROM ({}) WHERE rownum = 1", sql))
+    CXQuery::Wrapped(format!("SELECT * FROM ({}) WHERE 1=0", sql))
 
     // let ast = Parser::parse_sql(&OracleDialect {}, sql.as_str())?;
     // if ast.len() != 1 {


### PR DESCRIPTION
## Summary

Fixes #768 — Use `LIMIT 0` instead of `LIMIT 1` to get result schema, avoiding expensive query execution.

## Changes

### All sources except SQLite and Oracle
- Renamed `limit1_query` → `limit0_query` — returns only column metadata without reading any data rows.

### Oracle
- Uses `WHERE 1=0` (Oracle does not support `LIMIT`).

### SQLite
- Uses `conn.prepare()` + `stmt.columns()` to read `decl_type()` directly from the DDL — **no query execution at all**.
- Falls back to `LIMIT 1` only when `decl_type` is unavailable (computed expressions, aggregates like `COUNT(*)`, `AVG()`), where at least one row is needed to infer the type.
- This is strictly better than both `LIMIT 0` (which broke SQLite type inference) and `LIMIT 1` (which executed the full query plan).

## Improved behavior: empty result sets

Previously, queries returning zero rows would degrade all column types to `Text/object`. Now, schema discovery via `stmt.columns()` preserves the correct types even on empty results:

| Column | Before | After |
|--------|--------|-------|
| INTEGER | object | Int64 |
| REAL | object | float64 |
| BOOLEAN | object | boolean |
| DATE/DATETIME | object | datetime64[us] |
| TEXT | object | object |

Tests `test_empty_result` and `test_empty_result_on_partition` updated to reflect this improvement.

## Why not LIMIT 0 for SQLite?

SQLite's `query_row` with `LIMIT 0` returns `QueryReturnedNoRows`, providing no type information. The `stmt.columns()` approach gives schema metadata from the prepared statement without executing.

## Testing

- All existing Python SQLite tests pass (basic queries, partitions, LIMIT, aggregates, CTE, empty results, GROUP BY)
- All other sources compile and work unchanged with `limit0_query`
- `cargo check/clippy/fmt --features all` clean
