### PR TITLE
update ethnum 1.5.2 to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"


### PR DESCRIPTION
CI was down, so bump up ethnum.

```bash
--> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ethnum-1.5.2/src/error.rs:16:14
   |
16 |     unsafe { mem::transmute(()) }
   |              ^^^^^^^^^^^^^^
   |
   = note: source type: () (0 bits)
   = note: target type: TryFromIntError (8 bits)
    Checking debug_unsafe v0.1.3
For more information about this error, try rustc --explain E0512.
error: could not compile ethnum (lib) due to 1 previous error
Error: warning: build failed, waiting for other jobs to finish...
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```