### PR TITLE
fix(url): stop form-encoding connection URL parameters, and report unknown Postgres options as errors

### DIFF
--- a/connectorx/src/source_router.rs
+++ b/connectorx/src/source_router.rs
@@ -1,5 +1,6 @@
 use crate::constants::CONNECTORX_PROTOCOL;
 use crate::errors::{ConnectorXError, Result};
+use crate::utils::remove_query_params;
 use anyhow::anyhow;
 use fehler::throws;
 #[cfg(feature = "src_postgres")]
@@ -41,16 +42,7 @@ impl TryFrom<&str> for SourceConn {
         };
 
         // create url by removing connectorx protocol
-        let stripped_query: Vec<(_, _)> = old_url
-            .query_pairs()
-            .filter(|p| &*p.0 != CONNECTORX_PROTOCOL)
-            .collect();
-        let mut url = old_url.clone();
-        url.set_query(None);
-        for pair in stripped_query {
-            url.query_pairs_mut()
-                .append_pair(&pair.0.to_string()[..], &pair.1.to_string()[..]);
-        }
+        let url = remove_query_params(&old_url, &[CONNECTORX_PROTOCOL]);
 
         // users from sqlalchemy may set engine in connection url (e.g. mssql+pymssql://...)
         // only for compatablility, we don't use the same engine
@@ -92,4 +84,36 @@ pub fn parse_source(conn: &str, protocol: Option<&str>) -> SourceConn {
         None => {}
     }
     source_conn
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SourceConn;
+    use std::convert::TryFrom;
+
+    /// Removing the connectorx protocol must not re-encode the remaining parameters:
+    /// sources that percent-decode the query would otherwise receive a literal `+`
+    /// wherever the caller wrote a space.
+    #[test]
+    fn keeps_remaining_query_params_verbatim() {
+        let source_conn = SourceConn::try_from(
+            "postgresql://u:p@host:5432/db?options=-c%20statement_timeout%3D1s&cxprotocol=cursor",
+        )
+        .unwrap();
+
+        assert_eq!(
+            source_conn.conn.query(),
+            Some("options=-c%20statement_timeout%3D1s")
+        );
+        assert_eq!(source_conn.proto, "cursor");
+    }
+
+    /// The query is left alone even when there is no protocol parameter to remove.
+    #[test]
+    fn leaves_the_query_alone_when_there_is_nothing_to_remove() {
+        let source_conn = SourceConn::try_from("mysql://host:3306/db?a=x%20y&b=%2Fz").unwrap();
+
+        assert_eq!(source_conn.conn.query(), Some("a=x%20y&b=%2Fz"));
+        assert_eq!(source_conn.proto, "binary");
+    }
 }

--- a/connectorx/src/sources/postgres/connection.rs
+++ b/connectorx/src/sources/postgres/connection.rs
@@ -1,4 +1,5 @@
 use crate::sources::postgres::errors::PostgresSourceError;
+use crate::utils::remove_query_params;
 use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
 use postgres::{config::SslMode, Config};
 use postgres_openssl::MakeTlsConnector;
@@ -72,20 +73,7 @@ impl TryFrom<TlsConfig> for MakeTlsConnector {
 
 // Strip URL params not accepted by upstream rust-postgres
 fn strip_bad_opts(url: &Url) -> Url {
-    let stripped_query: Vec<(_, _)> = url
-        .query_pairs()
-        .filter(|p| !matches!(&*p.0, "sslkey" | "sslcert" | "sslrootcert"))
-        .collect();
-
-    let mut url2 = url.clone();
-    url2.set_query(None);
-
-    for pair in stripped_query {
-        url2.query_pairs_mut()
-            .append_pair(&pair.0.to_string()[..], &pair.1.to_string()[..]);
-    }
-
-    url2
+    remove_query_params(url, &["sslkey", "sslcert", "sslrootcert"])
 }
 
 pub fn rewrite_tls_args(
@@ -108,7 +96,7 @@ pub fn rewrite_tls_args(
     };
 
     let stripped_url = strip_bad_opts(conn);
-    let pg_config: Config = stripped_url.as_str().parse().unwrap();
+    let pg_config: Config = stripped_url.as_str().parse()?;
 
     let tls_config = TlsConfig {
         pg_config: pg_config.clone(),

--- a/connectorx/src/utils.rs
+++ b/connectorx/src/utils.rs
@@ -1,4 +1,41 @@
 use std::ops::{Deref, DerefMut};
+use url::{form_urlencoded, Url};
+
+/// Remove the given parameters from a URL query, leaving every other parameter
+/// byte-for-byte as the caller wrote it.
+///
+/// `Url::query_pairs_mut` cannot be used for this: it serializes the query as
+/// `application/x-www-form-urlencoded`, which encodes a space as `+`. Drivers that
+/// percent-decode the query (rust-postgres, for one) then read that `+` literally,
+/// so `?options=-c statement_timeout=1s` reaches the server as `-c+statement_timeout=1s`.
+pub(crate) fn remove_query_params(url: &Url, params: &[&str]) -> Url {
+    let mut stripped = url.clone();
+    match url.query() {
+        None => stripped,
+        Some(query) => {
+            let kept: Vec<&str> = query
+                .split('&')
+                .filter(|segment| !segment.is_empty())
+                .filter(|segment| {
+                    let raw_key = segment.split('=').next().unwrap_or_default();
+                    // compare decoded keys, as `query_pairs` would
+                    let key = form_urlencoded::parse(raw_key.as_bytes())
+                        .next()
+                        .map(|(key, _)| key)
+                        .unwrap_or_default();
+                    !params.contains(&&*key)
+                })
+                .collect();
+
+            let query = kept.join("&");
+            stripped.set_query(match query.is_empty() {
+                true => None,
+                false => Some(&query),
+            });
+            stripped
+        }
+    }
+}
 
 pub struct DummyBox<T>(pub T);
 
@@ -30,4 +67,79 @@ pub fn decimal_to_i128(mut v: rust_decimal::Decimal, scale: u32) -> anyhow::Resu
     }
 
     Ok(v.mantissa())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::remove_query_params;
+    use url::Url;
+
+    fn strip(uri: &str, params: &[&str]) -> String {
+        remove_query_params(&Url::parse(uri).unwrap(), params).to_string()
+    }
+
+    #[test]
+    fn preserves_spaces_in_values() {
+        assert_eq!(
+            strip(
+                "postgresql://u:p@host/db?options=-c%20statement_timeout%3D1s&cxprotocol=binary",
+                &["cxprotocol"]
+            ),
+            "postgresql://u:p@host/db?options=-c%20statement_timeout%3D1s"
+        );
+    }
+
+    #[test]
+    fn does_not_reencode_remaining_params() {
+        assert_eq!(
+            strip("mysql://host/db?a=x+y&b=%2Fz&flag", &["nothing"]),
+            "mysql://host/db?a=x+y&b=%2Fz&flag"
+        );
+    }
+
+    #[test]
+    fn removes_every_requested_param() {
+        assert_eq!(
+            strip(
+                "postgresql://host/db?sslcert=a&keep=1&sslkey=b&sslrootcert=c",
+                &["sslcert", "sslkey", "sslrootcert"]
+            ),
+            "postgresql://host/db?keep=1"
+        );
+    }
+
+    #[test]
+    fn drops_the_query_when_nothing_is_left() {
+        assert_eq!(
+            strip("postgresql://host/db?cxprotocol=binary", &["cxprotocol"]),
+            "postgresql://host/db"
+        );
+    }
+
+    #[test]
+    fn handles_a_missing_query() {
+        assert_eq!(
+            strip("postgresql://host/db", &["cxprotocol"]),
+            "postgresql://host/db"
+        );
+    }
+
+    #[test]
+    fn matches_percent_encoded_keys() {
+        assert_eq!(
+            strip(
+                "postgresql://host/db?cx%70rotocol=binary&a=1",
+                &["cxprotocol"]
+            ),
+            "postgresql://host/db?a=1"
+        );
+    }
+
+    #[test]
+    fn keeps_duplicate_keys_that_are_not_removed() {
+        assert_eq!(
+            strip("mysql://host/db?a=1&a=2&cxprotocol=text", &["cxprotocol"]),
+            "mysql://host/db?a=1&a=2"
+        );
+    }
 }

--- a/connectorx/tests/test_postgres.rs
+++ b/connectorx/tests/test_postgres.rs
@@ -23,6 +23,7 @@ use connectorx::{
     transports::PostgresArrowTransport,
 };
 use postgres::NoTls;
+use std::convert::TryFrom;
 use url::Url;
 
 mod test_db;
@@ -1442,4 +1443,62 @@ fn build_decimal_array(vals: Vec<Option<i128>>) -> Decimal128Array {
     }
 
     builder.finish()
+}
+
+fn query_single_string(url: &str, query: &str) -> String {
+    let source_conn = SourceConn::try_from(url).unwrap();
+    let destination = get_arrow(&source_conn, None, &[CXQuery::naked(query)], None).unwrap();
+    let batches = destination.arrow().unwrap();
+    batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .value(0)
+        .to_string()
+}
+
+/// A value containing a space must survive the URL rewriting: serializing the query
+/// as `application/x-www-form-urlencoded` would turn the space into a literal `+`.
+#[test]
+fn url_param_with_space_reaches_the_server() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let Some(dburl) = postgres_url_or_skip() else {
+        return;
+    };
+
+    let url = format!("{dburl}?application_name=cx%20e2e&cxprotocol=binary");
+    let application_name = query_single_string(
+        &url,
+        "SELECT application_name FROM pg_stat_activity WHERE pid = pg_backend_pid()",
+    );
+
+    assert_eq!(application_name, "cx e2e");
+}
+
+/// Session settings are passed as `options=-c name=value`, so the space between the
+/// `-c` flag and its argument has to reach the server intact.
+#[test]
+fn url_options_param_is_applied_by_the_server() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let Some(dburl) = postgres_url_or_skip() else {
+        return;
+    };
+
+    let url = format!("{dburl}?options=-c%20statement_timeout%3D1234ms");
+    let statement_timeout =
+        query_single_string(&url, "SELECT current_setting('statement_timeout')");
+
+    assert_eq!(statement_timeout, "1234ms");
+}
+
+/// An option upstream rust-postgres does not know about is a configuration error,
+/// not a reason to panic.
+#[test]
+fn unknown_url_param_is_reported_as_an_error() {
+    let url = Url::parse("postgresql://user:pass@localhost:5432/db?not_a_pg_option=1").unwrap();
+
+    assert!(rewrite_tls_args(&url).is_err());
 }


### PR DESCRIPTION
## Problem

Connection URL parameters whose value contains a space are corrupted before they reach the driver. With connectorx 0.4.5:

```python
import connectorx as cx

# ask the server for the application_name it sees
cx.read_sql(
    "postgresql://postgres:postgres@localhost:5432/testdb?application_name=my%20app",
    "SELECT application_name FROM pg_stat_activity WHERE pid = pg_backend_pid()",
)
# -> 'my+app'
```

The same substitution makes session settings unusable, which is the most common reason to put parameters in the URL at all:

```python
cx.read_sql(
    "postgresql://...?options=-c%20statement_timeout%3D1234ms",
    "SELECT current_setting('statement_timeout')",
)
# RuntimeError: db error: FATAL: unrecognized configuration parameter "+statement_timeout"
```

`%20`, `+` and a literal space all end up as `+`, so there is no way to express a space today. This is what pola-rs/polars#24488 runs into: the reporter has to strip `?options=-c%20default_transaction_read_only%3DTrue` from the URL when switching from `adbc` to `connectorx`.

Separately, a parameter that upstream rust-postgres does not recognize aborts the process:

```python
cx.read_sql("postgresql://...?totally_unknown_param=x", "SELECT 1")
# pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value:
#   Error { kind: ConfigParse, cause: Some(UnknownOption("totally_unknown_param")) }
```

## Cause

Two places rewrite the URL by rebuilding its query with `Url::query_pairs_mut().append_pair()`. That method serializes as `application/x-www-form-urlencoded`, where a space is written as `+`. Drivers that percent-decode the query — rust-postgres among them — then read that `+` literally.

- `SourceConn::try_from` (`source_router.rs`), when removing the `cxprotocol` parameter. This is the entry point for **every** source, so the bug is not Postgres-specific.
- `strip_bad_opts` (`sources/postgres/connection.rs`), when removing `sslkey` / `sslcert` / `sslrootcert`.

Both matter: fixing only one leaves the other to re-introduce the substitution. I verified that by reverting each site in turn and watching the new tests fail.

## Fix

A single helper, `remove_query_params`, filters the raw query segments and leaves the surviving parameters byte-for-byte as the caller wrote them, instead of decoding and re-encoding them. Both call sites use it. No new dependency: `form_urlencoded` is already re-exported by `url`, and is used only to compare parameter keys in decoded form, exactly as `query_pairs()` did.

`rewrite_tls_args` now propagates the `ConfigParse` error instead of calling `unwrap()`. `PostgresSourceError` already has `#[from] postgres::Error`, so this is a one-character change plus a test.

### This is not a behaviour change for callers who write `+`

| consumer | caller writes | before | after |
| --- | --- | --- | --- |
| percent-decoding (rust-postgres) | `%20` or a literal space | `+` | space |
| percent-decoding | `+` | `+` | `+` |
| form-decoding (`query_pairs`) | `%20` | space | space |
| form-decoding | `+` | space | space |

A caller who wrote `+` already got a literal `+`, because the old round-trip decoded `+` to a space and then re-encoded it back to `+`. Only values that were meant to contain a space change, and only from broken to correct. Parameters are now also passed through with the caller's own percent-encoding rather than a normalized one.

## Tests

Four new unit tests that need no database, so they run everywhere:

- `source_router::tests::keeps_remaining_query_params_verbatim` — `?options=-c%20statement_timeout%3D1s&cxprotocol=cursor` keeps `%20` and still picks up the protocol. Fails on `main` with `options=-c+statement_timeout%3D1s`.
- `source_router::tests::leaves_the_query_alone_when_there_is_nothing_to_remove` — also fails on `main`.
- Seven `utils::tests::*` covering the helper: spaces preserved, no re-encoding of `+`/`%2F`, multiple keys removed, query dropped when empty, missing query, percent-encoded keys, duplicate keys.

Three new integration tests in `tests/test_postgres.rs`, asserting the effect **on the server** rather than the shape of the string:

- `url_param_with_space_reaches_the_server` — `?application_name=cx%20e2e` and `pg_stat_activity` reports `cx e2e`. On `main`: `cx+e2e`.
- `url_options_param_is_applied_by_the_server` — `?options=-c%20statement_timeout%3D1234ms` and `current_setting('statement_timeout')` returns `1234ms`. On `main` the connection fails outright.
- `unknown_url_param_is_reported_as_an_error` — `rewrite_tls_args` returns `Err` instead of panicking.

Existing suites, run locally with the repository's testcontainers harness:

| suite | result |
| --- | --- |
| `test_postgres` | 21 passed, 0 failed |
| `test_mysql` | 28 passed, 0 failed |
| `test_trino` (including the `#[ignore]` ones) | 2 passed, 0 failed |
| `--lib` unit tests | 11 passed, 0 failed |

`cargo fmt --all -- --check` is clean, and `cargo clippy` reports nothing new on the touched files.

## Checked through the Python bindings too

I built the wheel from this branch and compared it against 0.4.5 on the same PostgreSQL 17 instance:

| case | 0.4.5 | this branch |
| --- | --- | --- |
| value containing a space | `'my+app'` | `'my app'` |
| `options=-c statement_timeout=1234ms` | `FATAL: unrecognized configuration parameter "+statement_timeout"` | `'1234ms'` |
| unrecognized parameter | `PanicException` | `RuntimeError: invalid connection string: unknown option ...` |

## What this unlocks for Polars

Polars is adding a `connection_options` parameter to `read_database_uri` (pola-rs/polars#29054), which merges a dict into the connection URI as query parameters for the connectorx engine. Values that contain a space — including the whole `options=-c name=value` family, which is how session settings are set — cannot work until this fix ships. With a wheel from this branch:

```python
pl.read_database_uri(
    "SELECT current_setting('statement_timeout')",
    "postgresql://postgres:postgres@localhost:5432/testdb",
    engine="connectorx",
    connection_options={"options": "-c statement_timeout=1234ms"},
)  # -> '1234ms'; on 0.4.5 the connection fails
```

That is also the scenario in pola-rs/polars#24488: one base URI reused across engines, with the extra parameters supplied separately, rather than stripped by hand for connectorx.

Related to pola-rs/polars#24488 and pola-rs/polars#29054.
