### PR TITLE
fix(oracle): map unconstrained NUMBER(0,0) to Decimal instead of float64

### DIFF
--- a/connectorx/src/sources/oracle/typesystem.rs
+++ b/connectorx/src/sources/oracle/typesystem.rs
@@ -40,7 +40,7 @@ impl<'a> From<&'a OracleType> for OracleTypeSystem {
     fn from(ty: &'a OracleType) -> OracleTypeSystem {
         use OracleTypeSystem::*;
         match ty {
-            OracleType::Number(0, 0) => NumFloat(true),
+            OracleType::Number(0, 0) => NumDecimal(true),
             OracleType::Number(_, 0) => NumInt(true),
             OracleType::Number(_, _) => NumDecimal(true),
             OracleType::Float(_) => Float(true),

--- a/docs/databases/oracle.md
+++ b/docs/databases/oracle.md
@@ -37,7 +37,8 @@ cx.read_sql(conn, query)
 | Oracle Type               |      Pandas Type            |  Comment                           |
 |:-------------------------:|:---------------------------:|:----------------------------------:|
 | Number(\*,0)              | int64, Int64(nullable)      |                                    |
-| Number(\*,>0)             | float64                     |                                    |
+| Number(0,0)               | object (Decimal)            | Unconstrained `NUMBER` (no precision/scale declared). Backed by `rust_decimal::Decimal`: exact, but limited to ~28-29 significant digits and a max scale of 28 — narrower than Oracle's own NUMBER limit (38 digits, scale -84..127). A value exceeding this will error rather than silently lose precision. |
+| Number(\*,>0)             | object (Decimal)            | Backed by `rust_decimal::Decimal`, same precision limit as above.  |
 | Float                     | float64                     |                                    |
 | BINARY_FLOAT              | float64                     |                                    |
 | BINARY_DOUBLE             | float64                     |                                    |


### PR DESCRIPTION
An Oracle `NUMBER` with no declared precision/scale (e.g. the result of `SUM()` or an arithmetic expression) was mapped to `NumFloat`, silently losing precision beyond f64's ~15-17 significant digits.

This routes it through the existing `NumDecimal`/`rust_decimal::Decimal` path instead, consistent with the `Number(*,>0)` case just below it.

Validated against a live Oracle instance: `SUM()` and arithmetic expressions over NUMBER columns now come back as exact decimal128 instead of float64.