### PR TITLE
feat: change mysql test image

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,7 +26,12 @@ services:
       - connectorx-network
 
   mysql:
-    image: ghcr.io/wangxiaoying/mysql:latest
+    image: mysql:8.0.25
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --init-connect=SET NAMES utf8mb4
     environment:
       MYSQL_DATABASE: mysql
       MYSQL_ROOT_PASSWORD: mysql

--- a/connectorx-python/connectorx/tests/conftest.py
+++ b/connectorx-python/connectorx/tests/conftest.py
@@ -186,10 +186,16 @@ def mysql_container() -> Generator[Optional[Any], None, None]:
         raise FileNotFoundError(f"MySQL init script not found: {init_script}")
 
     mysql_container = MySqlContainer(
-        image="ghcr.io/wangxiaoying/mysql:latest",
+        image="mysql:8.0.25",
         username="root",
         password="mysql",
         dbname="mysql",
+        command=[
+            "--character-set-server=utf8mb4",
+            "--collation-server=utf8mb4_unicode_ci",
+            "--skip-character-set-client-handshake",
+            "--init-connect=SET NAMES utf8mb4",
+        ],
     ).with_volume_mapping(str(init_script), "/docker-entrypoint-initdb.d/mysql.sql", mode="ro")
 
     with mysql_container as mysql:


### PR DESCRIPTION
The current tests use ghcr.io/wangxiaoying/mysql, a fork of official mysql:8.0.25. Checking it with docker history shows its CMD only adds defaults (utf8mb4) on top of `mysqld:
CMD ["mysqld", "--init-connect='SET NAMES utf8mb4'", "--skip-character-set-client-handshake", "--collation-server=utf8mb4_unicode_ci", "--character-set-server=utf8mb4"]`

This PR swaps to the official mysql:8.0.25 and passes those same settings as command arguments, so behavior is equivalent. TLS cannot be enabled on the wangxiaoying image (SSL_CTX_set_default_verify_paths failed), which blocks the TLS tests added in #922 from running in CI. The official image auto-provisions self-signed certificates on startup, so the #922 tests can be executed.

Verified with the full MySQL test suite (Python and Rust) producing the same results before and after. A follow-up PR will wire the TLS test fixtures into conftest.